### PR TITLE
Implement subscriptions reusage

### DIFF
--- a/examples/addressbook/addressbookengine.cpp
+++ b/examples/addressbook/addressbookengine.cpp
@@ -56,9 +56,9 @@ AddressBookEngine::AddressBookEngine() : QObject()
     std::shared_ptr<QtProtobuf::QAbstractGrpcChannel> channel(new QtProtobuf::QGrpcHttp2Channel(QUrl("https://localhost:65001"), QtProtobuf::QGrpcSslCredentials(conf) |
                                                                                       QtProtobuf::QGrpcUserPasswordCredentials<>("authorizedUser", QCryptographicHash::hash("test", QCryptographicHash::Md5).toHex())));
     m_client->attachChannel(channel);
-    m_client->subscribeContactsUpdates(ListFrame());
-    connect(m_client, &AddressBookClient::contactsUpdated, this, [this](const Contacts &contacts) {
-        m_contacts->reset(contacts.list());
+    auto subscription = m_client->subscribeContactsUpdates(ListFrame());
+    connect(subscription, &QtProtobuf::QGrpcSubscription::updated, this, [this, subscription]() {
+        m_contacts->reset(subscription->read<Contacts>().list());
     });
     m_client->subscribeCallStatusUpdates(qtprotobuf::examples::None(), QPointer<CallStatus>(&m_callStatus));
 }

--- a/examples/simplechat/simplechatengine.cpp
+++ b/examples/simplechat/simplechatengine.cpp
@@ -78,19 +78,19 @@ void SimpleChatEngine::login(const QString &name, const QString &password)
         qCritical() << "Subscription error, cancel";
         subscription->cancel();
     });
-    QObject::connect(m_client, &SimpleChatClient::messageListUpdated, this, [this, name](const qtprotobuf::examples::ChatMessages &messages) {
+    QObject::connect(subscription, &QtProtobuf::QGrpcSubscription::updated, this, [this, name, subscription]() {
         if (m_userName != name) {
             m_userName = name;
             userNameChanged();
             loggedIn();
         }
-        m_messages.reset(messages.messages());
+        m_messages.reset(subscription->read<qtprotobuf::examples::ChatMessages>().messages());
     });
 }
 
 void SimpleChatEngine::sendMessage(const QString &content)
 {
-    m_client->sendMessage(ChatMessage(QDateTime::currentMSecsSinceEpoch(), content.toUtf8(), ChatMessage::ContentType::Text));
+    m_client->sendMessage(ChatMessage(static_cast<quint64>(QDateTime::currentMSecsSinceEpoch()), content.toUtf8(), ChatMessage::ContentType::Text));
 }
 
 qtprotobuf::examples::ChatMessage::ContentType SimpleChatEngine::clipBoardContentType() const
@@ -146,7 +146,7 @@ void SimpleChatEngine::sendImageFromClipboard()
         return;
     }
 
-    m_client->sendMessage(ChatMessage(QDateTime::currentMSecsSinceEpoch(), imgData, qtprotobuf::examples::ChatMessage::ContentType::Image));
+    m_client->sendMessage(ChatMessage(static_cast<quint64>(QDateTime::currentMSecsSinceEpoch()), imgData, qtprotobuf::examples::ChatMessage::ContentType::Image));
 }
 
 QString SimpleChatEngine::getImageThumbnail(const QByteArray &data) const

--- a/src/generator/clientgenerator.cpp
+++ b/src/generator/clientgenerator.cpp
@@ -85,7 +85,6 @@ void ClientGenerator::printClientMethodsDeclaration()
         getMethodParameters(method, parameters);
 
         if (method->server_streaming()) {
-            mPrinter->Print(parameters, Templates::ClientMethodSignalDeclarationTemplate);
             mPrinter->Print(parameters, Templates::ClientMethodServerStreamDeclarationTemplate);
             mPrinter->Print(parameters, Templates::ClientMethodServerStream2DeclarationTemplate);
         } else {

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -269,11 +269,11 @@ const char *Templates::ClientMethodServerStreamDeclarationTemplate = "QtProtobuf
 const char *Templates::ClientMethodServerStream2DeclarationTemplate = "QtProtobuf::QGrpcSubscription *subscribe$method_name_upper$Updates(const $param_type$ &$param_name$, const QPointer<$return_type$> &$return_name$);\n";
 const char *Templates::ClientMethodServerStreamDefinitionTemplate = "QtProtobuf::QGrpcSubscription *$classname$::subscribe$method_name_upper$Updates(const $param_type$ &$param_name$)\n"
                                                                     "{\n"
-                                                                    "    return subscribe(\"$method_name$\", $param_name$, &$classname$::$method_name$Updated);\n"
+                                                                    "    return subscribe(\"$method_name$\", $param_name$);\n"
                                                                     "}\n";
 const char *Templates::ClientMethodServerStream2DefinitionTemplate = "QtProtobuf::QGrpcSubscription *$classname$::subscribe$method_name_upper$Updates(const $param_type$ &$param_name$, const QPointer<$return_type$> &$return_name$)\n"
                                                                      "{\n"
-                                                                     "    return subscribe(\"$method_name$\", $param_name$, $return_name$, &$classname$::$method_name$Updated);\n"
+                                                                     "    return subscribe(\"$method_name$\", $param_name$, $return_name$);\n"
                                                                      "}\n";
 
 const char *Templates::ListSuffix = "Repeated";

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -14,7 +14,8 @@ set(CMAKE_AUTORCC ON)
 include(${QTPROTOBUF_CMAKE_DIR}/Coverage.cmake)
 include(${QTPROTOBUF_CMAKE_DIR}/GenerateQtHeaders.cmake)
 
-file(GLOB SOURCES qgrpcasyncreply.cpp
+file(GLOB SOURCES qgrpcasyncoperationbase.cpp
+    qgrpcasyncreply.cpp
     qgrpcsubscription.cpp
     qgrpcstatus.cpp
     qabstractgrpcchannel.cpp
@@ -25,7 +26,8 @@ file(GLOB SOURCES qgrpcasyncreply.cpp
     qgrpcinsecurecredentials.cpp
     qgrpcuserpasswordcredentials.cpp)
 
-file(GLOB HEADERS qgrpcasyncreply.h
+file(GLOB HEADERS qgrpcasyncoperationbase_p.h
+    qgrpcasyncreply.h
     qgrpcsubscription.h
     qgrpcstatus.h
     qabstractgrpcchannel.h

--- a/src/grpc/qgrpcasyncoperationbase.cpp
+++ b/src/grpc/qgrpcasyncoperationbase.cpp
@@ -23,25 +23,16 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "qgrpcsubscription.h"
+#include "qgrpcasyncoperationbase_p.h"
 
 #include <qtprotobuflogging.h>
 
 using namespace QtProtobuf;
 
-QGrpcSubscription::QGrpcSubscription(const std::shared_ptr<QAbstractGrpcChannel> &channel, const QString &method,
-                                     const QByteArray &arg, const SubscriptionHandler &handler, QAbstractGrpcClient *parent) : QGrpcAsyncOperationBase(channel, parent)
-  , m_method(method)
-  , m_arg(arg)
+QGrpcAsyncOperationBase::~QGrpcAsyncOperationBase()
 {
-    if (handler) {
-        m_handlers.push_back(handler);
-    }
-}
-
-void QGrpcSubscription::addHandler(const SubscriptionHandler &handler)
-{
-    if (handler) {
-        m_handlers.push_back(handler);
-    }
+    qProtoDebug() << "Trying ~QGrpcAsyncOperationBase" << this;
+    QMutexLocker locker(&m_asyncLock);
+    qProtoDebug() << "~QGrpcAsyncOperationBase" << this;
+    (void)locker;
 }

--- a/src/grpc/qgrpcasyncoperationbase_p.h
+++ b/src/grpc/qgrpcasyncoperationbase_p.h
@@ -1,0 +1,110 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexey Edelev <semlanik@gmail.com>
+ *
+ * This file is part of QtProtobuf project https://git.semlanik.org/semlanik/qtprotobuf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QMutex>
+
+#include <functional>
+#include <memory>
+
+#include "qabstractgrpcchannel.h"
+#include "qabstractgrpcclient.h"
+
+#include "qtgrpcglobal.h"
+
+namespace QtProtobuf {
+
+class Q_GRPC_EXPORT QGrpcAsyncOperationBase : public QObject
+{
+    Q_OBJECT
+public:
+    /*!
+     * \brief Reads message from raw byte array stored in QGrpcAsyncReply
+     * \return Copy of deserialized message or non-initialized message in case of exceptional situation
+     */
+    template <typename T>
+    T read() {
+        QMutexLocker locker(&m_asyncLock);
+        T value;
+        try {
+            value.deserialize(static_cast<QAbstractGrpcClient*>(parent())->serializer(), m_data);
+        } catch (std::invalid_argument &) {
+            static const QLatin1String invalidArgumentErrorMessage("Response deserialization failed invalid field found");
+            error({QGrpcStatus::InvalidArgument, invalidArgumentErrorMessage});
+        } catch (std::out_of_range &) {
+            static const QLatin1String outOfRangeErrorMessage("Invalid size of received buffer");
+            error({QGrpcStatus::OutOfRange, outOfRangeErrorMessage});
+        } catch (...) {
+            error({QGrpcStatus::Internal, QLatin1String("Unknown exception caught during deserialization")});
+        }
+        return value;
+    }
+
+    /*!
+     * \brief Interface for implementation of QAbstractGrpcChannel. Should be used to write raw data from channel to
+     *        reply
+     * \param data Raw data received from channel
+     */
+    void setData(const QByteArray &data)
+    {
+        QMutexLocker locker(&m_asyncLock);
+        m_data = data;
+    }
+
+signals:
+    /*!
+     * \brief The signal is emitted when reply is ready for read. Usualy called by channel when all chunks of data
+     *        recevied
+     */
+    void finished();
+
+    /*!
+     * \brief The signal is emitted when error happend in channel or during serialization
+     * \param code gRPC channel QGrpcStatus::StatusCode
+     * \param errorMessage Description of error occured
+     */
+    void error(const QGrpcStatus &status);
+
+protected:
+    //! \private
+    QGrpcAsyncOperationBase(const std::shared_ptr<QAbstractGrpcChannel> &channel, QAbstractGrpcClient *parent) : QObject(parent)
+      , m_channel(channel) {}
+    //! \private
+    virtual ~QGrpcAsyncOperationBase();
+
+    std::shared_ptr<QAbstractGrpcChannel> m_channel;
+private:
+    QGrpcAsyncOperationBase();
+    Q_DISABLE_COPY_MOVE(QGrpcAsyncOperationBase)
+
+    friend class QAbstractGrpcClient;
+
+    QByteArray m_data;
+    QMutex m_asyncLock;
+};
+
+}

--- a/src/grpc/qgrpcasyncreply.cpp
+++ b/src/grpc/qgrpcasyncreply.cpp
@@ -24,14 +24,5 @@
  */
 
 #include "qgrpcasyncreply.h"
-#include <qtprotobuflogging.h>
 
 using namespace QtProtobuf;
-
-QGrpcAsyncReply::~QGrpcAsyncReply()
-{
-    qProtoDebug() << "Trying ~QGrpcAsyncReply" << this;
-    QMutexLocker locker(&m_asyncLock);
-    qProtoDebug() << "~QGrpcAsyncReply" << this;
-    (void)locker;
-}

--- a/src/grpc/qgrpcasyncreply.h
+++ b/src/grpc/qgrpcasyncreply.h
@@ -31,6 +31,7 @@
 
 #include "qabstractgrpcchannel.h"
 #include "qabstractgrpcclient.h"
+#include "qgrpcasyncoperationbase_p.h"
 
 #include "qtgrpcglobal.h"
 
@@ -42,43 +43,10 @@ namespace QtProtobuf {
  *        created it. QGrpcAsyncReply coul be used by QAbstractGrpcChannel implementations to control call work flow and
  *        abort calls if possible in case if QGrpcAsyncReply::abort method called by library user.
  */
-class Q_GRPC_EXPORT QGrpcAsyncReply final : public QObject
+class Q_GRPC_EXPORT QGrpcAsyncReply final : public QGrpcAsyncOperationBase
 {
     Q_OBJECT
 public:
-    /*!
-     * \brief Reads message from raw byte array stored in QGrpcAsyncReply
-     * \return Copy of deserialized message or non-initialized message in case of exceptional situation
-     */
-    template <typename T>
-    T read() {
-        QMutexLocker locker(&m_asyncLock);
-        T value;
-        try {
-            value.deserialize(static_cast<QAbstractGrpcClient*>(parent())->serializer(), m_data);
-        } catch (std::invalid_argument &) {
-            static const QLatin1String invalidArgumentErrorMessage("Response deserialization failed invalid field found");
-            error({QGrpcStatus::InvalidArgument, invalidArgumentErrorMessage});
-        } catch (std::out_of_range &) {
-            static const QLatin1String outOfRangeErrorMessage("Invalid size of received buffer");
-            error({QGrpcStatus::OutOfRange, outOfRangeErrorMessage});
-        } catch (...) {
-            error({QGrpcStatus::Internal, QLatin1String("Unknown exception caught during deserialization")});
-        }
-        return value;
-    }
-
-    /*!
-     * \brief Interface for implementation of QAbstractGrpcChannel. Should be used to write raw data from channel to
-     *        reply
-     * \param data Raw data received from channel
-     */
-    void setData(const QByteArray &data)
-    {
-        QMutexLocker locker(&m_asyncLock);
-        m_data = data;
-    }
-
     /*!
      * \brief Aborts this reply and try to abort call in channel
      */
@@ -108,36 +76,17 @@ public:
         QObject::connect(this, &QGrpcAsyncReply::finished, receiver, finishCallback, type);
     }
 
-signals:
-    /*!
-     * \brief The signal is emitted when reply is ready for read. Usualy called by channel when all chunks of data
-     *        recevied
-     */
-    void finished();
-
-    /*!
-     * \brief The signal is emitted when error happend in channel or during serialization
-     * \param code gRPC channel QGrpcStatus::StatusCode
-     * \param errorMessage Description of error occured
-     */
-    void error(const QGrpcStatus &status);
-
 protected:
     //! \private
-    QGrpcAsyncReply(const std::shared_ptr<QAbstractGrpcChannel> &channel, QAbstractGrpcClient *parent = nullptr) : QObject(parent)
-    , m_channel(channel) {}
+    QGrpcAsyncReply(const std::shared_ptr<QAbstractGrpcChannel> &channel, QAbstractGrpcClient *parent) : QGrpcAsyncOperationBase(channel, parent)
+    {}
     //! \private
-    ~QGrpcAsyncReply();
+    ~QGrpcAsyncReply() = default;
 
 private:
     QGrpcAsyncReply();
     Q_DISABLE_COPY_MOVE(QGrpcAsyncReply)
 
     friend class QAbstractGrpcClient;
-
-    std::shared_ptr<QAbstractGrpcChannel> m_channel;
-    QByteArray m_data;
-
-    QMutex m_asyncLock;
 };
 }


### PR DESCRIPTION
- Remove update signals from generated clients. It's required because
  of multiple subscriptions possible for single streaming method.
  If user whould like to subscribe multiple times, it's not possible
  to determine which subscription invoked signal.
- Add subscription reusage mechanism
- Implement tests for ducplicates
- Make QGrpcSubscription to serve multiple handlers