### PR TITLE
Fix well-know-types build for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_subdirectory("src/protobuf")
 add_subdirectory("src/grpc")
 add_subdirectory("src/generator")
-if(NOT WIN32)#TODO: There are linking issues with windows build of well-known types...
-    add_subdirectory("src/wellknowntypes")
-endif()
+add_subdirectory("src/wellknowntypes")
+
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/ProjectConfig.cmake.in" "${QT_PROTOBUF_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake")

--- a/cmake/QtProtobufGen.cmake
+++ b/cmake/QtProtobufGen.cmake
@@ -144,11 +144,9 @@ function(qtprotobuf_generate)
             $<TARGET_PROPERTY:${QT_PROTOBUF_PROJECT}::QtGrpc,INTERFACE_INCLUDE_DIRECTORIES>)
     endif()
 
-    if(NOT WIN32)
-        if(TARGET ${QT_PROTOBUF_PROJECT}::QtProtobufWellKnownTypes)
-            target_include_directories(${GENERATED_TARGET_NAME} PRIVATE
-                $<TARGET_PROPERTY:${QT_PROTOBUF_PROJECT}::QtProtobufWellKnownTypes,INTERFACE_INCLUDE_DIRECTORIES>)
-        endif()
+    if(TARGET ${QT_PROTOBUF_PROJECT}::QtProtobufWellKnownTypes)
+        target_include_directories(${GENERATED_TARGET_NAME} PRIVATE
+            $<TARGET_PROPERTY:${QT_PROTOBUF_PROJECT}::QtProtobufWellKnownTypes,INTERFACE_INCLUDE_DIRECTORIES>)
     endif()
 
     #Automatically link whole static library to specified in parameters target

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,4 @@ add_subdirectory("test_grpc")
 add_subdirectory("test_qml")
 add_subdirectory("test_protobuf_multifile")
 add_subdirectory("test_qprotobuf_serializer_plugin")
-if(NOT WIN32)#TODO: There are linking issues with windows build of well-known types...
-	add_subdirectory("test_wellknowntypes")
-endif()
+add_subdirectory("test_wellknowntypes")


### PR DESCRIPTION
- Add QT_GENERATED_LIB definition support to export generated
  symbols in windows
- Add qtprotobuf_link_archive function that provides possibility
  to link generated targets as "whole archive"

Fixes: #12