### PR TITLE
Migrate to cAmEl case field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,23 +297,23 @@ QtProtobuf::qRegisterProtobufTypes();
 
 ## Code exceptions
 
-If any prohibited Qt/QML keyword is used as field name, generator appends '*Proto*' suffix to generated filed name. It's required to omit overloading for example QML reserved names like '*id*' or '*objectName*'.
+If any prohibited Qt/QML keyword is used as field name, generator appends '*_proto*' suffix to generated filed name. It's required to omit overloading for example QML reserved names like '*id*' or '*objectName*'.
 
 E.g. for message:
 ```
 message MessageReserved {
-sint32 import = 1;
-sint32 property = 2;
-sint32 id = 3;
+    sint32 import = 1;
+    sint32 property = 2;
+    sint32 id = 3;
 }
 ```
 
 Following properties will be generated:
 ```cpp
 ...
-Q_PROPERTY(QtProtobuf::sint32 importProto READ importProto WRITE setImport NOTIFY importProtoChanged)
-Q_PROPERTY(QtProtobuf::sint32 propertyProto READ propertyProto WRITE setProperty NOTIFY propertyProtoChanged)
-Q_PROPERTY(QtProtobuf::sint32 idProto READ idProto WRITE setId NOTIFY idProtoChanged)
+    Q_PROPERTY(QtProtobuf::sint32 import_proto READ import_proto WRITE setImport_proto NOTIFY import_protoChanged SCRIPTABLE true)
+    Q_PROPERTY(QtProtobuf::sint32 property_proto READ property_proto WRITE setProperty_proto NOTIFY property_protoChanged SCRIPTABLE true)
+    Q_PROPERTY(QtProtobuf::sint32 id_proto READ id_proto WRITE setId_proto NOTIFY id_protoChanged SCRIPTABLE true)
 ...
 
 ```

--- a/src/generator/classgeneratorbase.cpp
+++ b/src/generator/classgeneratorbase.cpp
@@ -332,9 +332,6 @@ bool ClassGeneratorBase::producePropertyMap(const google::protobuf::Descriptor *
     std::string typeNameLower(typeName);
     utils::tolower(typeNameLower);
 
-    std::string capProperty = field->name();
-    capProperty[0] = static_cast<char>(::toupper(capProperty[0]));
-
     std::string typeNameNoList = typeName;
     if (field->is_repeated() && !field->is_map()) {
         if(field->type() == FieldDescriptor::TYPE_MESSAGE
@@ -361,9 +358,12 @@ bool ClassGeneratorBase::producePropertyMap(const google::protobuf::Descriptor *
         getterType = "const " + getterType;
     }
 
-    std::string fieldName = utils::lowerCaseName(field->name());
-
+    std::string fieldName = utils::lowerCaseName(field->camelcase_name());
     fieldName = qualifiedName(fieldName);
+
+    std::string capProperty = fieldName;
+    capProperty[0] = static_cast<char>(::toupper(capProperty[0]));
+
     propertyMap = {{"type", typeName},
                    {"classname", utils::upperCaseName(message->name())},
                    {"type_lower", typeNameLower},

--- a/src/generator/protobufsourcegenerator.cpp
+++ b/src/generator/protobufsourcegenerator.cpp
@@ -124,7 +124,7 @@ void ProtobufSourceGenerator::printConstructor()
     for (int i = 0; i < mMessage->field_count(); i++) {
         const FieldDescriptor *field = mMessage->field(i);
         std::string fieldTypeName = getTypeName(field, mMessage);
-        std::string fieldName = utils::lowerCaseName(field->name());
+        std::string fieldName = utils::lowerCaseName(field->camelcase_name());
         fieldName = qualifiedName(fieldName);
 
         if (field->is_repeated() || field->is_map()) {
@@ -169,7 +169,7 @@ void ProtobufSourceGenerator::printConstructor()
                          {"parameter_list", parameters}}, Templates::ProtoConstructorDefinitionTemplate);
         for (size_t j = 0; j < parameterList.size(); j++) {
             const FieldDescriptor *field = mMessage->field(j);
-            std::string fieldName = utils::lowerCaseName(field->name());
+            std::string fieldName = utils::lowerCaseName(field->camelcase_name());
             auto fieldTypeName = getTypeName(field, mMessage);
             fieldName = qualifiedName(fieldName);
             if (field->type() == FieldDescriptor::TYPE_MESSAGE
@@ -227,7 +227,7 @@ void ProtobufSourceGenerator::printCopyFunctionality()
                     Templates::CopyConstructorDefinitionTemplate);
     for (int j = 0; j < mMessage->field_count(); j++) {
         const FieldDescriptor *field = mMessage->field(j);
-        std::string fieldName = utils::lowerCaseName(field->name());
+        std::string fieldName = utils::lowerCaseName(field->camelcase_name());
         auto fieldTypeName = getTypeName(field, mMessage);
         fieldName = qualifiedName(fieldName);
 
@@ -273,7 +273,7 @@ void ProtobufSourceGenerator::printMoveSemantic()
                     Templates::MoveConstructorDefinitionTemplate);
     for (int j = 0; j < mMessage->field_count(); j++) {
         const FieldDescriptor *field = mMessage->field(j);
-        std::string fieldName = utils::lowerCaseName(field->name());
+        std::string fieldName = utils::lowerCaseName(field->camelcase_name());
         auto fieldTypeName = getTypeName(field, mMessage);
         fieldName = qualifiedName(fieldName);
 

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -27,7 +27,7 @@
 
 using namespace QtProtobuf::generator;
 
-const char *Templates::ProtoSufix = "Proto";
+const char *Templates::ProtoSufix = "_proto";
 
 const std::vector<std::string> Templates::ListOfQmlExeptions{"id", "property", "import"};
 

--- a/tests/test_protobuf/simpletest.cpp.inc
+++ b/tests/test_protobuf/simpletest.cpp.inc
@@ -776,11 +776,11 @@ TEST_F(SimpleTest, UnderscoresTest)
     FollowingMessageUnderscoreField msg5;
     CombinedMessageUnderscoreField msg6;
 
-    assertMessagePropertyRegistered<MessageUnderscoreField, sint32>(1, "QtProtobuf::sint32", "underScore_Message_field");
-    assertMessagePropertyRegistered<PriorMessageUnderscoreField, sint32>(1, "QtProtobuf::sint32", "_underScoreMessageField");
-    assertMessagePropertyRegistered<PriorMessageUnderscoreField, sint32>(1, "QtProtobuf::sint32", "_underScoreMessageField");
-    assertMessagePropertyRegistered<FollowingMessageUnderscoreField , sint32>(1, "QtProtobuf::sint32", "underScoreMessageField_");
-    assertMessagePropertyRegistered<CombinedMessageUnderscoreField , sint32>(1, "QtProtobuf::sint32", "_underScoreMessage_Field_");
+    assertMessagePropertyRegistered<MessageUnderscoreField, sint32>(1, "QtProtobuf::sint32", "underScoreMessageField");
+    assertMessagePropertyRegistered<PriorMessageUnderscoreField, sint32>(1, "QtProtobuf::sint32", "underScoreMessageField");
+    assertMessagePropertyRegistered<PriorMessageUnderscoreField, sint32>(1, "QtProtobuf::sint32", "underScoreMessageField");
+    assertMessagePropertyRegistered<FollowingMessageUnderscoreField , sint32>(1, "QtProtobuf::sint32", "underScoreMessageField");
+    assertMessagePropertyRegistered<CombinedMessageUnderscoreField , sint32>(1, "QtProtobuf::sint32", "underScoreMessageField");
 }
 
 TEST_F(SimpleTest, SequenceTest)
@@ -802,16 +802,16 @@ TEST_F(SimpleTest, UpperCaseTest)
 
 TEST_F(SimpleTest, ReservedTest)
 {
-    assertMessagePropertyRegistered<MessageReserved, sint32>(1, "QtProtobuf::sint32", "importProto");
-    assertMessagePropertyRegistered<MessageReserved, sint32>(2, "QtProtobuf::sint32", "propertyProto");
-    assertMessagePropertyRegistered<MessageReserved, sint32>(3, "QtProtobuf::sint32", "idProto");
+    assertMessagePropertyRegistered<MessageReserved, sint32>(1, "QtProtobuf::sint32", "import_proto");
+    assertMessagePropertyRegistered<MessageReserved, sint32>(2, "QtProtobuf::sint32", "property_proto");
+    assertMessagePropertyRegistered<MessageReserved, sint32>(3, "QtProtobuf::sint32", "id_proto");
 }
 
 TEST_F(SimpleTest, ReservedUpperCaseTest)
 {
-    assertMessagePropertyRegistered<MessageUpperCaseReserved, sint32>(1, "QtProtobuf::sint32", "importProto");
-    assertMessagePropertyRegistered<MessageUpperCaseReserved, sint32>(2, "QtProtobuf::sint32", "propertyProto");
-    assertMessagePropertyRegistered<MessageUpperCaseReserved, sint32>(3, "QtProtobuf::sint32", "idProto");
+    assertMessagePropertyRegistered<MessageUpperCaseReserved, sint32>(1, "QtProtobuf::sint32", "import_proto");
+    assertMessagePropertyRegistered<MessageUpperCaseReserved, sint32>(2, "QtProtobuf::sint32", "property_proto");
+    assertMessagePropertyRegistered<MessageUpperCaseReserved, sint32>(3, "QtProtobuf::sint32", "id_proto");
 }
 
 TEST_F(SimpleTest, ReservedEnumTest)

--- a/tests/test_qml/qml/tst_simple.qml
+++ b/tests/test_qml/qml/tst_simple.qml
@@ -205,12 +205,12 @@ TestCase {
     }
 
     function test_reservedNames() {
-        reservedMsg.idProto = 34;
-        reservedMsg.importProto = 35;
-        reservedMsg.propertyProto = 36;
-        compare(reservedMsg.idProto, 34, "reservedMsg.idProto == 34")
-        compare(reservedMsg.importProto, 35, "reservedMsg.importProto == 35")
-        compare(reservedMsg.propertyProto, 36, "reservedMsg.propertyProto == 36")
+        reservedMsg.id_proto = 34;
+        reservedMsg.import_proto = 35;
+        reservedMsg.property_proto = 36;
+        compare(reservedMsg.id_proto, 34, "reservedMsg.id_proto == 34")
+        compare(reservedMsg.import_proto, 35, "reservedMsg.import_proto == 35")
+        compare(reservedMsg.property_proto, 36, "reservedMsg.property_proto == 36")
     }
 
     function test_reservedEnums() {
@@ -229,8 +229,8 @@ TestCase {
     }
 
     function test_underScoreField() {
-        underScoreMsg._underScoreMessageField = 123
-        compare(underScoreMsg._underScoreMessageField, 123, "underScoreMsg._underScoreMessageField == 123")
+        underScoreMsg.underScoreMessageField = 123
+        compare(underScoreMsg.underScoreMessageField, 123, "underScoreMsg.underScoreMessageField == 123")
     }
 
     function test_lowerCaseMessage() {

--- a/tests/test_wellknowntypes/simpletest.cpp
+++ b/tests/test_wellknowntypes/simpletest.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<QProtobufSerializer> WellknowntypesTest::serializer;
 TEST_F(WellknowntypesTest, AnyTest)
 {
     ASSERT_GT(qMetaTypeId<Any>(), 0);
-    assertMessagePropertyRegistered<Any, QString>(1, "QString", "type_url");
+    assertMessagePropertyRegistered<Any, QString>(1, "QString", "typeUrl");
     assertMessagePropertyRegistered<Any, QByteArray>(2, "QByteArray", "value");
 }
 
@@ -93,7 +93,7 @@ TEST_F(WellknowntypesTest, ApiTest)
     assertMessagePropertyRegistered<Api, MethodRepeated>(2, "MethodRepeated", "methods");
     assertMessagePropertyRegistered<Api, OptionRepeated>(3, "OptionRepeated", "options");
     assertMessagePropertyRegistered<Api, QString>(4, "QString", "version");
-    assertMessagePropertyRegistered<Api, SourceContext>(5, "SourceContext*", "source_context", true);
+    assertMessagePropertyRegistered<Api, SourceContext>(5, "SourceContext*", "sourceContext", true);
     assertMessagePropertyRegistered<Api, MixinRepeated>(6, "MixinRepeated", "mixins");
     assertMessagePropertyRegistered<Api, SyntaxGadget::Syntax>(7, "google::protobuf::SyntaxGadget::Syntax", "syntax");
 }
@@ -102,10 +102,10 @@ TEST_F(WellknowntypesTest, MethodTest)
 {
     ASSERT_GT(qMetaTypeId<Method>(), 0);
     assertMessagePropertyRegistered<Method, QString>(1, "QString", "name");
-    assertMessagePropertyRegistered<Method, QString>(2, "QString", "request_type_url");
-    assertMessagePropertyRegistered<Method, bool>(3, "bool", "request_streaming");
-    assertMessagePropertyRegistered<Method, QString>(4, "QString", "response_type_url");
-    assertMessagePropertyRegistered<Method, bool>(5, "bool", "response_streaming");
+    assertMessagePropertyRegistered<Method, QString>(2, "QString", "requestTypeUrl");
+    assertMessagePropertyRegistered<Method, bool>(3, "bool", "requestStreaming");
+    assertMessagePropertyRegistered<Method, QString>(4, "QString", "responseTypeUrl");
+    assertMessagePropertyRegistered<Method, bool>(5, "bool", "responseStreaming");
     assertMessagePropertyRegistered<Method, OptionRepeated>(6, "OptionRepeated", "options");
     assertMessagePropertyRegistered<Method, SyntaxGadget::Syntax>(7, "google::protobuf::SyntaxGadget::Syntax", "syntax");
 }
@@ -138,7 +138,7 @@ TEST_F(WellknowntypesTest, FieldMaskTest)
 TEST_F(WellknowntypesTest, SourceContextTest)
 {
     ASSERT_GT(qMetaTypeId<SourceContext>(), 0);
-    assertMessagePropertyRegistered<SourceContext, QString>(1, "QString", "file_name");
+    assertMessagePropertyRegistered<SourceContext, QString>(1, "QString", "fileName");
 }
 
 TEST_F(WellknowntypesTest, StructTest)
@@ -150,12 +150,12 @@ TEST_F(WellknowntypesTest, StructTest)
 TEST_F(WellknowntypesTest, ValueTest)
 {
     ASSERT_GT(qMetaTypeId<Value>(), 0);
-    assertMessagePropertyRegistered<Value, NullValueGadget::NullValue>(1, "google::protobuf::NullValueGadget::NullValue", "null_value");
-    assertMessagePropertyRegistered<Value, double>(2, "double", "number_value");
-    assertMessagePropertyRegistered<Value, QString>(3, "QString", "string_value");
-    assertMessagePropertyRegistered<Value, bool>(4, "bool", "bool_value");
-    assertMessagePropertyRegistered<Value, Struct *>(5, "Struct*", "struct_value");
-    assertMessagePropertyRegistered<Value, ListValue *>(6, "ListValue*", "list_value");
+    assertMessagePropertyRegistered<Value, NullValueGadget::NullValue>(1, "google::protobuf::NullValueGadget::NullValue", "nullValue");
+    assertMessagePropertyRegistered<Value, double>(2, "double", "numberValue");
+    assertMessagePropertyRegistered<Value, QString>(3, "QString", "stringValue");
+    assertMessagePropertyRegistered<Value, bool>(4, "bool", "boolValue");
+    assertMessagePropertyRegistered<Value, Struct *>(5, "Struct*", "structValue");
+    assertMessagePropertyRegistered<Value, ListValue *>(6, "ListValue*", "listValue");
 }
 
 TEST_F(WellknowntypesTest, ListValueTest)
@@ -180,7 +180,7 @@ TEST_F(WellknowntypesTest, TypeTest)
     assertMessagePropertyRegistered<Type, FieldRepeated>(2, "FieldRepeated", "fields");
     assertMessagePropertyRegistered<Type, QStringList>(3, "QStringList", "oneofs");
     assertMessagePropertyRegistered<Type, OptionRepeated>(4, "OptionRepeated", "options");
-    assertMessagePropertyRegistered<Type, SourceContext *>(5, "SourceContext*", "source_context", true);
+    assertMessagePropertyRegistered<Type, SourceContext *>(5, "SourceContext*", "sourceContext", true);
     assertMessagePropertyRegistered<Type, SyntaxGadget::Syntax>(6, "google::protobuf::SyntaxGadget::Syntax", "syntax");
 }
 
@@ -192,12 +192,12 @@ TEST_F(WellknowntypesTest, FieldTest)
     assertMessagePropertyRegistered<Field, Field::Cardinality>(2, "Cardinality", "cardinality");
     assertMessagePropertyRegistered<Field, QtProtobuf::int32>(3, "QtProtobuf::int32", "number_p");
     assertMessagePropertyRegistered<Field, QString>(4, "QString", "name");
-    assertMessagePropertyRegistered<Field, QString>(6, "QString", "type_url");
-    assertMessagePropertyRegistered<Field, QtProtobuf::int32>(7, "QtProtobuf::int32", "oneof_index_p");
+    assertMessagePropertyRegistered<Field, QString>(6, "QString", "typeUrl");
+    assertMessagePropertyRegistered<Field, QtProtobuf::int32>(7, "QtProtobuf::int32", "oneofIndex_p");
     assertMessagePropertyRegistered<Field, bool>(8, "bool", "packed");
     assertMessagePropertyRegistered<Field, OptionRepeated>(9, "OptionRepeated", "options");
-    assertMessagePropertyRegistered<Field, QString>(10, "QString", "json_name");
-    assertMessagePropertyRegistered<Field, QString>(11, "QString", "default_value");
+    assertMessagePropertyRegistered<Field, QString>(10, "QString", "jsonName");
+    assertMessagePropertyRegistered<Field, QString>(11, "QString", "defaultValue");
 }
 
 TEST_F(WellknowntypesTest, EnumTest)
@@ -206,7 +206,7 @@ TEST_F(WellknowntypesTest, EnumTest)
     assertMessagePropertyRegistered<Enum, QString>(1, "QString", "name");
     assertMessagePropertyRegistered<Enum, EnumValueRepeated>(2, "EnumValueRepeated", "enumvalue");
     assertMessagePropertyRegistered<Enum, OptionRepeated>(3, "OptionRepeated", "options");
-//    assertMessagePropertyRegistered<Enum, SourceContext *>(4, "SourceContext*", "source_context");
+//    assertMessagePropertyRegistered<Enum, SourceContext *>(4, "SourceContext*", "sourceContext");
     assertMessagePropertyRegistered<Enum, SyntaxGadget::Syntax>(5, "google::protobuf::SyntaxGadget::Syntax", "syntax");
 }
 


### PR DESCRIPTION
- From this point QtProtobuf will use standard protobuf name
  converter for field names to camel case