### PR TITLE
Fix empty message warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(UNIX)
 elseif(WIN32)
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 #TODO: not all l4 warnings are fixed for MSVC. Enable options bellow
-#once fixed
+#      once fixed
 #        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX /W4 /MD")
 #        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX /W4 /MD")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /wd4005")

--- a/src/generator/protobufsourcegenerator.cpp
+++ b/src/generator/protobufsourcegenerator.cpp
@@ -223,8 +223,17 @@ void ProtobufSourceGenerator::printConstructor()
 
 void ProtobufSourceGenerator::printCopyFunctionality()
 {
+    assert(mMessage != nullptr);
+
+    const char *constructorTemplate = Templates::CopyConstructorDefinitionTemplate;
+    const char *assignmentOperatorTemplate = Templates::AssignmentOperatorDefinitionTemplate;
+    if (mMessage->field_count() <= 0) {
+        constructorTemplate = Templates::EmptyCopyConstructorDefinitionTemplate;
+        assignmentOperatorTemplate = Templates::EmptyAssignmentOperatorDefinitionTemplate;
+    }
+
     mPrinter->Print({{"classname", mClassName}},
-                    Templates::CopyConstructorDefinitionTemplate);
+                    constructorTemplate);
     for (int j = 0; j < mMessage->field_count(); j++) {
         const FieldDescriptor *field = mMessage->field(j);
         std::string fieldName = utils::lowerCaseName(field->camelcase_name());
@@ -251,7 +260,7 @@ void ProtobufSourceGenerator::printCopyFunctionality()
     mPrinter->Print(Templates::SimpleBlockEnclosureTemplate);
 
     mPrinter->Print({{"classname", mClassName}},
-                    Templates::AssignmentOperatorDefinitionTemplate);
+                    assignmentOperatorTemplate);
     Indent();
     for (int i = 0; i < mMessage->field_count(); i++) {
         auto field = mMessage->field(i);
@@ -269,8 +278,16 @@ void ProtobufSourceGenerator::printCopyFunctionality()
 void ProtobufSourceGenerator::printMoveSemantic()
 {
     assert(mMessage != nullptr);
+
+    const char *constructorTemplate = Templates::MoveConstructorDefinitionTemplate;
+    const char *assignmentOperatorTemplate = Templates::MoveAssignmentOperatorDefinitionTemplate;
+    if (mMessage->field_count() <= 0) {
+        constructorTemplate = Templates::EmptyMoveConstructorDefinitionTemplate;
+        assignmentOperatorTemplate = Templates::EmptyMoveAssignmentOperatorDefinitionTemplate;
+    }
+
     mPrinter->Print({{"classname", mClassName}},
-                    Templates::MoveConstructorDefinitionTemplate);
+                    constructorTemplate);
     for (int j = 0; j < mMessage->field_count(); j++) {
         const FieldDescriptor *field = mMessage->field(j);
         std::string fieldName = utils::lowerCaseName(field->camelcase_name());
@@ -306,7 +323,7 @@ void ProtobufSourceGenerator::printMoveSemantic()
     mPrinter->Print(Templates::SimpleBlockEnclosureTemplate);
 
     mPrinter->Print({{"classname", mClassName}},
-                    Templates::MoveAssignmentOperatorDefinitionTemplate);
+                    assignmentOperatorTemplate);
     Indent();
     for (int i = 0; i < mMessage->field_count(); i++) {
         const FieldDescriptor *field = mMessage->field(i);
@@ -333,13 +350,16 @@ void ProtobufSourceGenerator::printMoveSemantic()
 void ProtobufSourceGenerator::printComparisonOperators()
 {
     assert(mMessage != nullptr);
+    if (mMessage->field_count() <= 0) {
+        mPrinter->Print({{"classname", mClassName}}, Templates::EmptyEqualOperatorDefinitionTemplate);
+        mPrinter->Print({{"classname", mClassName}}, Templates::NotEqualOperatorDefinitionTemplate);
+        return;
+    }
+
     PropertyMap properties;
     mPrinter->Print({{"classname", mClassName}}, Templates::EqualOperatorDefinitionTemplate);
 
     bool isFirst = true;
-    if (mMessage->field_count() <= 0) {
-        mPrinter->Print("true");
-    }
     for (int i = 0; i < mMessage->field_count(); i++) {
         const FieldDescriptor *field = mMessage->field(i);
         if (producePropertyMap(mMessage, field, properties)) {

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -105,6 +105,8 @@ const char *Templates::CopyConstructorDeclarationTemplate = "$classname$(const $
 const char *Templates::MoveConstructorDeclarationTemplate = "$classname$($classname$ &&other);\n";
 const char *Templates::CopyConstructorDefinitionTemplate = "$classname$::$classname$(const $classname$ &other) : QObject()";
 const char *Templates::MoveConstructorDefinitionTemplate = "$classname$::$classname$($classname$ &&other) : QObject()";
+const char *Templates::EmptyCopyConstructorDefinitionTemplate = "$classname$::$classname$(const $classname$ &) : QObject()";
+const char *Templates::EmptyMoveConstructorDefinitionTemplate = "$classname$::$classname$($classname$ &&) : QObject()";
 const char *Templates::DeletedCopyConstructorTemplate = "$classname$(const $classname$ &) = delete;\n";
 const char *Templates::DeletedMoveConstructorTemplate = "$classname$($classname$ &&) = delete;\n";
 const char *Templates::CopyFieldTemplate = "set$property_name_cap$(other.m_$property_name$);\n";
@@ -128,14 +130,19 @@ const char *Templates::EnumMoveFieldTemplate = "m_$property_name$ = other.m_$pro
 
 const char *Templates::AssignmentOperatorDeclarationTemplate = "$classname$ &operator =(const $classname$ &other);\n";
 const char *Templates::AssignmentOperatorDefinitionTemplate = "$classname$ &$classname$::operator =(const $classname$ &other)\n{\n";
+const char *Templates::EmptyAssignmentOperatorDefinitionTemplate = "$classname$ &$classname$::operator =(const $classname$ &)\n{\n";
 const char *Templates::AssignmentOperatorReturnTemplate = "return *this;\n";
 
 const char *Templates::MoveAssignmentOperatorDeclarationTemplate = "$classname$ &operator =($classname$ &&other);\n";
 const char *Templates::MoveAssignmentOperatorDefinitionTemplate = "$classname$ &$classname$::operator =($classname$ &&other)\n{\n";
+const char *Templates::EmptyMoveAssignmentOperatorDefinitionTemplate = "$classname$ &$classname$::operator =($classname$ &&)\n{\n";
 
 const char *Templates::EqualOperatorDeclarationTemplate = "bool operator ==(const $classname$ &other) const;\n";
 const char *Templates::EqualOperatorDefinitionTemplate = "bool $classname$::operator ==(const $classname$ &other) const\n{\n"
-                                               "    return ";
+                                                         "    return ";
+const char *Templates::EmptyEqualOperatorDefinitionTemplate = "bool $classname$::operator ==(const $classname$ &) const\n{\n"
+                                                              "    return true;\n"
+                                                              "}\n\n";
 const char *Templates::EqualOperatorPropertyTemplate = "m_$property_name$ == other.m_$property_name$";
 const char *Templates::EqualOperatorMessagePropertyTemplate = "*m_$property_name$ == *other.m_$property_name$";
 

--- a/src/generator/templates.h
+++ b/src/generator/templates.h
@@ -86,6 +86,8 @@ public:
     static const char *MoveConstructorDeclarationTemplate;
     static const char *CopyConstructorDefinitionTemplate;
     static const char *MoveConstructorDefinitionTemplate;
+    static const char *EmptyCopyConstructorDefinitionTemplate;
+    static const char *EmptyMoveConstructorDefinitionTemplate;
     static const char *DeletedCopyConstructorTemplate;
     static const char *DeletedMoveConstructorTemplate;
     static const char *CopyFieldTemplate;
@@ -97,11 +99,14 @@ public:
     static const char *EnumMoveFieldTemplate;
     static const char *AssignmentOperatorDeclarationTemplate;
     static const char *AssignmentOperatorDefinitionTemplate;
+    static const char *EmptyAssignmentOperatorDefinitionTemplate;
     static const char *AssignmentOperatorReturnTemplate;
     static const char *MoveAssignmentOperatorDeclarationTemplate;
     static const char *MoveAssignmentOperatorDefinitionTemplate;
+    static const char *EmptyMoveAssignmentOperatorDefinitionTemplate;
     static const char *EqualOperatorDeclarationTemplate;
     static const char *EqualOperatorDefinitionTemplate;
+    static const char *EmptyEqualOperatorDefinitionTemplate;
     static const char *EqualOperatorPropertyTemplate;
     static const char *EqualOperatorMessagePropertyTemplate;
     static const char *NotEqualOperatorDeclarationTemplate;


### PR DESCRIPTION
- Add empty message copy and move functions with no argument
  passed as parameter

Fixes: #94