### PR TITLE
Fix static build for well-known types

### DIFF
--- a/cmake/QtProtobufGen.cmake
+++ b/cmake/QtProtobufGen.cmake
@@ -143,7 +143,7 @@ function(qtprotobuf_generate)
 
     add_custom_target(${GEN_TARGET} DEPENDS ${GENERATED_SOURCES_FULL} ${GENERATED_HEADERS_FULL} ${qtprotobuf_generate_PROTO_FILES})
 
-    add_library(${GENERATED_TARGET_NAME} ${GENERATED_SOURCES_FULL} ${MOC_SOURCES})
+    add_library(${GENERATED_TARGET_NAME} OBJECT ${GENERATED_SOURCES_FULL} ${MOC_SOURCES})
     add_dependencies(${GENERATED_TARGET_NAME} ${GEN_TARGET})
     set_target_properties(${GENERATED_TARGET_NAME} PROPERTIES PUBLIC_HEADER "${GENERATED_HEADERS_FULL}")
 
@@ -165,6 +165,7 @@ function(qtprotobuf_generate)
 
     #Automatically link whole static library to specified in parameters target
     if(DEFINED qtprotobuf_generate_TARGET)
-        qtprotobuf_link_archive(${qtprotobuf_generate_TARGET} ${GENERATED_TARGET_NAME})
+        target_sources(${qtprotobuf_generate_TARGET} PRIVATE $<TARGET_OBJECTS:${GENERATED_TARGET_NAME}>)
+        target_include_directories(${qtprotobuf_generate_TARGET} PRIVATE $<TARGET_PROPERTY:${GENERATED_TARGET_NAME},INTERFACE_INCLUDE_DIRECTORIES>)
     endif()
 endfunction()

--- a/examples/addressbookserver/CMakeLists.txt
+++ b/examples/addressbookserver/CMakeLists.txt
@@ -10,6 +10,13 @@ set_source_files_properties(${GENERATED_SOURCES} PROPERTIES GENERATED TRUE)
 add_executable(${TARGET} main.cpp ${GENERATED_SOURCES})
 target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+if(UNIX)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        # using GCC
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=array-bounds")
+    endif()
+endif()
+
 file(GLOB PROTO_FILES ABSOLUTE ${CMAKE_CURRENT_SOURCE_DIR}/../addressbook/proto/*.proto)
 protobuf_generate_all(TARGET ${TARGET}
     GENERATED_SOURCES ${GENERATED_SOURCES}

--- a/examples/simplechatserver/CMakeLists.txt
+++ b/examples/simplechatserver/CMakeLists.txt
@@ -10,6 +10,13 @@ set_source_files_properties(${GENERATED_SOURCES} PROPERTIES GENERATED TRUE)
 add_executable(${TARGET} main.cpp ${GENERATED_SOURCES})
 target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
+if(UNIX)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        # using GCC
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=array-bounds")
+    endif()
+endif()
+
 file(GLOB PROTO_FILES ABSOLUTE ${CMAKE_CURRENT_SOURCE_DIR}/../simplechat/proto/*.proto)
 protobuf_generate_all(TARGET ${TARGET}
     GENERATED_SOURCES ${GENERATED_SOURCES}

--- a/src/wellknowntypes/CMakeLists.txt
+++ b/src/wellknowntypes/CMakeLists.txt
@@ -44,7 +44,7 @@ function(add_wellknowntype TYPENAME)
     endforeach()
 endfunction()
 
-if(QT_PROTOBUF_STATIC AND NOT WIN32)
+if(QT_PROTOBUF_STATIC)
     add_library(${TARGET} STATIC ${SOURCES})
 else()
     add_library(${TARGET} SHARED ${SOURCES})

--- a/tests/test_qml/CMakeLists.txt
+++ b/tests/test_qml/CMakeLists.txt
@@ -15,7 +15,7 @@ if(TARGET QtProtobufProject::QtProtobufWellKnownTypes)
     target_link_libraries(${TARGET} PRIVATE QtProtobufProject::QtProtobufWellKnownTypes)
 endif()
 
-qtprotobuf_link_archive(${TARGET} qtprotobuf_test_qtprotobuf_gen)
+target_link_libraries(${TARGET} PRIVATE qtprotobuf_test_qtprotobuf_gen)
 
 add_target_qml(TARGET ${TARGET} QML_FILES ${QML_FILES})
 add_target_windeployqt(TARGET ${TARGET} QML_DIR ${CMAKE_CURRENT_SOURCE_DIR}/qml)

--- a/tests/test_qprotobuf_serializer_plugin/CMakeLists.txt
+++ b/tests/test_qprotobuf_serializer_plugin/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(${TARGET} ${SOURCES})
 target_link_libraries(${TARGET} PRIVATE gtest_main gtest ${QT_PROTOBUF_PROJECT}::QtProtobuf ${QT_PROTOBUF_PROJECT}::QtGrpc Qt5::Core Qt5::Test Qt5::Network ${CMAKE_THREAD_LIBS_INIT})
-qtprotobuf_link_archive(${TARGET} qtprotobuf_test_qtprotobuf_gen)
 add_target_windeployqt(TARGET ${TARGET}
     QML_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
- Migrate to OBJECT library for generated code
- Cleanup cmake procedures

Fixes: #113