### PR TITLE
Add Conan support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ set(QT_PROTOBUF_PROJECT QtProtobufProject)
 
 project(${QT_PROTOBUF_PROJECT} VERSION ${QT_PROTOBUF_VERSION} LANGUAGES CXX)
 
+# Conan support, optional
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 include(GNUInstallDirs)
 
 set(QT_PROTOBUF_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,52 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class QtProtobufConan(ConanFile):
+    name = "qtprotobuf"
+    version = "0.4.0"
+    license = "MIT"
+    url = "https://github.com/semlanik/qtprotobuf"
+    description = ("gRPC and Protobuf generator and bindings for Qt framework")
+    topics = ("conan", "qt", "protobuf")
+    settings = "os", "compiler", "build_type", "arch"
+    homepage = "https://github.com/semlanik/qtprotobuf"
+    options = {"shared": [True, False]}
+    default_options = {
+        "shared": False,
+        "qt:qtdeclarative": True,
+    }
+    generators = "cmake"
+    requires = [
+        "protobuf/3.9.1",
+        "protoc_installer/3.9.1@bincrafters/stable",
+        "qt/5.14.2@bincrafters/stable",
+        "grpc/1.25.0@inexorgame/stable",
+        "openssl/1.1.1d",
+    ]
+    scm = {
+        "type": "git",
+        "url": "auto",
+        "revision": "auto",
+    }
+    exports_sources = "*"
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["QT_PROTOBUF_MAKE_EXAMPLES"] = "OFF"
+        cmake.definitions["QT_PROTOBUF_MAKE_TESTS"] = "OFF"
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+        cmake.install()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.configure()
+        cmake.install()
+
+        self.copy("LICENSE", dst="licenses")
+

--- a/src/protobuf/CMakeLists.txt
+++ b/src/protobuf/CMakeLists.txt
@@ -11,7 +11,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 find_package(Qt5 COMPONENTS Core Qml REQUIRED)
-find_package(microjson CONFIG REQUIRED)
+if(NOT TARGET microjson)
+    find_package(microjson CONFIG REQUIRED)
+endif()
 
 include(${QT_PROTOBUF_CMAKE_DIR}/Coverage.cmake)
 include(${QT_PROTOBUF_CMAKE_DIR}/GenerateQtHeaders.cmake)


### PR DESCRIPTION
Added basic Conan support.
Conan installs compiler and libraries correctly, but I couldn't make it install QML modules to a correct location, because that location (QT_INSTALL_QML) is actually located inside another package. So I doubt, that this issue could be resolved without some changes to Qt package or to Conan itself.
Also, it depends on grpc from this repo: https://github.com/inexorgame/conan-grpc, at least, until grpc hits bincrafters or conan-center.