### PR TITLE
Add "returnValue" property to qml GrpcSubscription

### DIFF
--- a/src/grpc/quick/qquickgrpcsubscription.cpp
+++ b/src/grpc/quick/qquickgrpcsubscription.cpp
@@ -54,6 +54,7 @@ void QQuickGrpcSubscription::updateSubscription()
     if (m_returnValue != nullptr) {
         m_returnValue->deleteLater(); //TODO: probably need to take care about return value cleanup other way. It's just reminder about weak memory management.
         m_returnValue = nullptr;
+        returnValueChanged();
     }
 
     if (m_client.isNull() || m_method.isEmpty() || !m_enabled || m_argument.isNull()) {
@@ -143,6 +144,8 @@ bool QQuickGrpcSubscription::subscribe()
         error({QGrpcStatus::Unknown, errorString});
         return false;
     }
+
+    returnValueChanged();
 
     QGrpcSubscription *subscription = nullptr;
     bool ok = method.invoke(m_client, Qt::DirectConnection,

--- a/src/grpc/quick/qquickgrpcsubscription.cpp
+++ b/src/grpc/quick/qquickgrpcsubscription.cpp
@@ -138,14 +138,14 @@ bool QQuickGrpcSubscription::subscribe()
     m_returnValue = reinterpret_cast<QObject*>(returnMetaType.create());
     qmlEngine(this)->setObjectOwnership(m_returnValue, QQmlEngine::CppOwnership);
 
+    returnValueChanged();
+
     if (m_returnValue == nullptr) {
         errorString = "Unable to allocate return value. Unknown metatype system error";
         qProtoWarning() << errorString;
         error({QGrpcStatus::Unknown, errorString});
         return false;
     }
-
-    returnValueChanged();
 
     QGrpcSubscription *subscription = nullptr;
     bool ok = method.invoke(m_client, Qt::DirectConnection,

--- a/src/grpc/quick/qquickgrpcsubscription_p.h
+++ b/src/grpc/quick/qquickgrpcsubscription_p.h
@@ -55,6 +55,9 @@
  * \subsubsection argument QObject *argument
  * \details Pointer to argument that will be used for subscription.
  *
+ * \subsubsection returnValue QObject *returnValue
+ * \details Value returned by the subscription (Note that it is the same "return" object passed by the "updated" signal)
+ *
  * \subsection Signals
  * \subsubsection updated updated(ReturnType value)
  * \details The signal notifies about received update for subscription. It provides "return" value ready for use in QML.
@@ -97,6 +100,7 @@ class QQuickGrpcSubscription : public QObject
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     Q_PROPERTY(QString method READ method WRITE setMethod NOTIFY methodChanged)
     Q_PROPERTY(QObject *argument READ argument WRITE setArgument NOTIFY argumentChanged)
+    Q_PROPERTY(QObject *returnValue READ returnValue NOTIFY returnValueChanged)
 
 public:
     QQuickGrpcSubscription(QObject *parent = nullptr);
@@ -116,6 +120,10 @@ public:
 
     QObject *argument() const {
         return m_argument;
+    }
+
+    QObject *returnValue() const {
+        return m_returnValue;
     }
 
     void setClient(QAbstractGrpcClient *client) {
@@ -166,6 +174,7 @@ signals:
     void methodChanged();
     void enabledChanged();
     void argumentChanged();
+    void returnValueChanged();
 
 private:
     void updateSubscription();


### PR DESCRIPTION
The property allows to propagate the value changed event to any object which is bound to a property of the return value: this way there is no need to update manually the values through the updated callback.

That way, given the following example proto file:

```proto
service Analyzer {
  rpc Subscribe (google.protobuf.Empty) returns (stream State);
}

message State {
  bool on = 1;
}
```

Once subscribed with GrpcSubscription i can listen for updates from the stream directly with the returnValue property:

```qml
GrpcSubscription {
  id: sub
  client: AnalyzerClient
  method: "Subscribe"
  argument: Empty {}
  enabled: true
}


Text {
  text: sub.returnValue.on
}
```