### PR TITLE
Reset all fields to default values before serialization

### DIFF
--- a/src/protobuf/qabstractprotobufserializer.h
+++ b/src/protobuf/qabstractprotobufserializer.h
@@ -92,13 +92,22 @@ public:
      *          Bytes corresponding to unexpected properties are skipped without any exception
      *
      * \param[out] object Pointer to memory where result of deserialization should be injected
-     * \param[in] array Bytes with serialized message
+     * \param[in] data Bytes with serialized message
      */
     template<typename T>
-    void deserialize(QObject *object, const QByteArray &array) {
+    void deserialize(T *object, const QByteArray &data) {
         Q_ASSERT(object != nullptr);
         qProtoDebug() << T::staticMetaObject.className() << "deserialize";
-        deserializeMessage(object, T::protobufMetaObject, array);
+        //Initialize default object first and make copy aferwards, it's necessary to set default
+        //values of properties that was not stored in data.
+        T newValue;
+        try {
+            deserializeMessage(&newValue, T::protobufMetaObject, data);
+        } catch(...) {
+            *object = newValue;
+            throw;
+        }
+        *object = newValue;
     }
 
     virtual ~QAbstractProtobufSerializer() = default;

--- a/src/protobuf/qprotobufjsonserializer.cpp
+++ b/src/protobuf/qprotobufjsonserializer.cpp
@@ -342,7 +342,7 @@ public:
                 QByteArray rawValue = QByteArray::fromStdString(property.second.value);
                 if (rawValue == "null" && property.second.type == microjson::JsonObjectType) {
                     object->setProperty(name.c_str(), QVariant());//Initialize with default value
-                    return;
+                    continue;
                 }
                 bool ok = false;
                 QVariant value = deserializeValue(userType, rawValue, property.second.type, ok);

--- a/tests/test_protobuf/deserializationtest.cpp
+++ b/tests/test_protobuf/deserializationtest.cpp
@@ -272,9 +272,8 @@ TEST_F(DeserializationTest, IntMessageDeserializeTest)
     test.deserialize(serializer.get(), QByteArray::fromHex("08898004"));
     ASSERT_EQ(65545, test.testFieldInt());
 
-    //FIXME: bug#68
-    //test.deserialize(serializer.get(), QByteArray::fromHex(""));
-    //ASSERT_EQ(0, test.testFieldInt());
+    test.deserialize(serializer.get(), QByteArray::fromHex(""));
+    ASSERT_EQ(0, test.testFieldInt());
 
     test.deserialize(serializer.get(), QByteArray::fromHex("088001"));
     ASSERT_EQ(INT8_MAX + 1, test.testFieldInt());
@@ -488,8 +487,6 @@ TEST_F(DeserializationTest, RepeatedComplexMessageTest)
     ASSERT_EQ(25, test.testRepeatedComplex().at(2)->testFieldInt());
     ASSERT_TRUE(test.testRepeatedComplex().at(2)->testComplexField().testFieldString() == QString("qwerty"));
 
-    //FIXME: This setter should not be called in this test. See bug#69
-    test.setTestRepeatedComplex({});
     test.deserialize(serializer.get(), QByteArray::fromHex("0a1508d3feffffffffffffff0112083206717765727479"));
     ASSERT_LT(0, test.testRepeatedComplex().count());
     ASSERT_EQ(-173, test.testRepeatedComplex().at(0)->testFieldInt());
@@ -508,9 +505,8 @@ TEST_F(DeserializationTest, SIntMessageDeserializeTest)
     test.deserialize(serializer.get(), QByteArray::fromHex("08928008"));
     ASSERT_EQ(65545, test.testFieldInt());
 
-    //FIXME: bug#68
-    //test.deserialize(serializer.get(), QByteArray::fromHex(""));
-    //ASSERT_EQ(0, test.testFieldInt());
+    test.deserialize(serializer.get(), QByteArray::fromHex(""));
+    ASSERT_EQ(0, test.testFieldInt());
 
     test.deserialize(serializer.get(), QByteArray::fromHex("088002"));
     ASSERT_EQ(INT8_MAX + 1, test.testFieldInt());
@@ -564,9 +560,8 @@ TEST_F(DeserializationTest, UIntMessageDeserializeTest)
     test.deserialize(serializer.get(), QByteArray::fromHex("08898004"));
     ASSERT_EQ(65545, test.testFieldInt());
 
-    //FIXME: bug#68
-    //test.deserialize(serializer.get(), QByteArray::fromHex(""));
-    //ASSERT_EQ(0, test.testFieldInt());
+    test.deserialize(serializer.get(), QByteArray::fromHex(""));
+    ASSERT_EQ(0, test.testFieldInt());
 
     test.deserialize(serializer.get(), QByteArray::fromHex("088002"));
     ASSERT_EQ(UINT8_MAX + 1, test.testFieldInt());
@@ -590,8 +585,7 @@ TEST_F(DeserializationTest, BoolDeserializeTest)
     test.deserialize(serializer.get(), QByteArray::fromHex("0801"));
     ASSERT_EQ(test.testFieldBool(), true);
 
-    //FIXME: bug#68
-    //test.deserialize(serializer.get(), QByteArray::fromHex(""));
+    test.deserialize(serializer.get(), QByteArray::fromHex(""));
     test.deserialize(serializer.get(), QByteArray::fromHex("0800"));
     ASSERT_EQ(test.testFieldBool(), false);
 }

--- a/tests/test_protobuf/jsondeserializationtest.cpp
+++ b/tests/test_protobuf/jsondeserializationtest.cpp
@@ -310,8 +310,8 @@ TEST_F(JsonDeserializationTest, ComplexTypeSerializeTest)
     EXPECT_STREQ(test.testComplexField().testFieldString().toStdString().c_str(), "qwerty");
     EXPECT_EQ(test.testFieldInt(), -45);
 
-    test.deserialize(serializer.get(), QByteArray("{\"testFieldInt\":-45,\"testComplexField\":null"));
-    EXPECT_STREQ(test.testComplexField().testFieldString().toStdString().c_str(), "qwerty");
+    test.deserialize(serializer.get(), QByteArray("{\"testFieldInt\":-45,\"testComplexField\":null}"));
+    EXPECT_STREQ(test.testComplexField().testFieldString().toStdString().c_str(), "");
     EXPECT_EQ(test.testFieldInt(), -45);
 
 }
@@ -528,7 +528,7 @@ TEST_F(JsonDeserializationTest, BoolMessageSerializeTest)
 
     test.setTestFieldBool(true);
     test.deserialize(serializer.get(), "{\"testFieldBool\":0}");
-    EXPECT_TRUE(test.testFieldBool());
+    EXPECT_FALSE(test.testFieldBool());
 
     test.setTestFieldBool(false);
     test.deserialize(serializer.get(), "{\"testFieldBool\":\"true\"}");
@@ -536,7 +536,7 @@ TEST_F(JsonDeserializationTest, BoolMessageSerializeTest)
 
     test.setTestFieldBool(true);
     test.deserialize(serializer.get(), "{\"testFieldBool\":\"false\"}");
-    EXPECT_TRUE(test.testFieldBool());
+    EXPECT_FALSE(test.testFieldBool());
 
     test.setTestFieldBool(false);
     test.deserialize(serializer.get(), "{\"testFieldBool\":1.0}");
@@ -544,7 +544,7 @@ TEST_F(JsonDeserializationTest, BoolMessageSerializeTest)
 
     test.setTestFieldBool(true);
     test.deserialize(serializer.get(), "{\"testFieldBool\":0.0}");
-    EXPECT_TRUE(test.testFieldBool());
+    EXPECT_FALSE(test.testFieldBool());
 }
 
 TEST_F(JsonDeserializationTest, SimpleEnumMessageSerializeTest)


### PR DESCRIPTION
- Make all fields default before serialization. It's required to
  update values for fields that was not present in serialized blob

Fixes: #142