### PR TITLE
Add a QML RPC method with the return value as a parameter

### DIFF
--- a/src/generator/clientdeclarationprinter.cpp
+++ b/src/generator/clientdeclarationprinter.cpp
@@ -88,6 +88,7 @@ void ClientDeclarationPrinter::printClientMethodsDeclaration()
             mPrinter->Print(parameters, Templates::ClientMethodDeclarationAsync2Template);
             if (GeneratorOptions::instance().hasQml()) {
                 mPrinter->Print(parameters, Templates::ClientMethodDeclarationQmlTemplate);
+                mPrinter->Print(parameters, Templates::ClientMethodDeclarationQml2Template);
             }
         }
         mPrinter->Print("\n");

--- a/src/generator/clientdefinitionprinter.cpp
+++ b/src/generator/clientdefinitionprinter.cpp
@@ -59,6 +59,7 @@ void ClientDefinitionPrinter::printMethods()
             mPrinter->Print(parameters, Templates::ClientMethodDefinitionAsync2Template);
             if (GeneratorOptions::instance().hasQml()) {
                 mPrinter->Print(parameters, Templates::ClientMethodDefinitionQmlTemplate);
+                mPrinter->Print(parameters, Templates::ClientMethodDefinitionQml2Template);
             }
         }
     }

--- a/src/generator/templates.h
+++ b/src/generator/templates.h
@@ -185,6 +185,7 @@ public:
     static const char *ClientMethodDeclarationAsyncTemplate;
     static const char *ClientMethodDeclarationAsync2Template;
     static const char *ClientMethodDeclarationQmlTemplate;
+    static const char *ClientMethodDeclarationQml2Template;
 
     static const char *ServerMethodDeclarationTemplate;
 
@@ -192,6 +193,7 @@ public:
     static const char *ClientMethodDefinitionAsyncTemplate;
     static const char *ClientMethodDefinitionAsync2Template;
     static const char *ClientMethodDefinitionQmlTemplate;
+    static const char *ClientMethodDefinitionQml2Template;
 
     //Streaming
     static const char *ClientMethodSignalDeclarationTemplate;

--- a/tests/test_grpc_qml/qml/tst_grpc.qml
+++ b/tests/test_grpc_qml/qml/tst_grpc.qml
@@ -206,4 +206,17 @@ TestCase {
         compare(subscriptionLoader.item.updateCount, 1, "Subscription failed, update was not called right amount times")
         subscriptionLoader.active = false;
     }
+
+    SimpleStringMessage {
+        id: returnStringMsg
+    }
+
+    function test_returnValueAsParameter() {
+        var errorCalled = false;
+        TestServiceClient.testMethod(stringMsg, returnStringMsg, function(status) {
+            errorCalled = true
+        })
+        wait(300)
+        compare(returnStringMsg.testFieldString == stringMsg.testFieldString && !errorCalled, true, "testMethod was not called proper way")
+    }
 }


### PR DESCRIPTION
Hi @semlanik,

This pull request implements a new fature in the generator that adds a new QML RPC method that in place of the second callback accepts a pointer to the return object. An example is reported below:

```qml
Message {
  id: arg
}

Message {
  id: ret
}

function call() {
  client.method(arg, ret, function(err) {
    console.log("Error");
  }
}
```

I've implemented a simple test, too.