### PR TITLE
working example of field enums

### DIFF
--- a/examples/fieldenum/README.md
+++ b/examples/fieldenum/README.md
@@ -1,0 +1,16 @@
+Field Number Enumerations
+===
+
+In `protobuf3`, fields are by default `optional`.
+When a field is not assigned (or, if it is not present in the version of the
+`.proto` file that the sender was using), a default value will be assigned to
+the field when it is deserialized by the message recipient.
+This, however, leads to an ambiguity as to whether the field was assigned a
+value which happened to be the default value, or whether it was not set at
+all by the sender.
+
+Preceeding the invocation of `protoc` with `QT_PROTOBUF_OPTIONS="FIELDENUM"`
+results in additional enums being added to the `.qpb.h` files that are generated.
+These can be useful to indicate which fields were actually set when the
+message was created.
+This could be compared to setting a field to `NULL` in a SQL database.

--- a/examples/fieldenum/field_enum_example.cpp
+++ b/examples/fieldenum/field_enum_example.cpp
@@ -1,0 +1,9 @@
+#include "field_enum_example.qpb.h"
+
+int main(int argc, char** argv)
+{
+    qtprotobuf::examples::SparseMessage msg;
+    msg.setNumberOfKids(0);
+    msg.setFieldsUsed({qtprotobuf::examples::SparseMessage::NumberOfKidsProtoFieldNumber});
+    return 0;
+}

--- a/examples/fieldenum/field_enum_example.pro
+++ b/examples/fieldenum/field_enum_example.pro
@@ -1,0 +1,6 @@
+
+QT += protobuf grpc core
+
+SOURCES = field_enum_example.cpp
+PROTO_FILES = field_enum_example.proto
+qtprotobuf_generate(false)

--- a/examples/fieldenum/field_enum_example.proto
+++ b/examples/fieldenum/field_enum_example.proto
@@ -1,0 +1,21 @@
+
+syntax="proto3";
+
+package qtprotobuf.examples;
+
+message SparseMessage {
+    repeated uint32 fieldsUsed = 1;
+    bool   attendedParty = 2;
+    uint32 numberOfKids  = 3;
+    string nickName      = 4;
+}
+
+message ExplicitMessage {
+    enum PARTY_STATUS {ATTENDED=0; DIDNT_ATTEND=1; DIDNT_ASK=2;};
+    PARTY_STATUS attendedParty = 1;
+    bool   indicatedKids = 2;
+    uint32 numberOfKids  = 3;
+    enum NO_NICK_STATUS {HAS_NO_NICKNAMES=0; WOULD_NOT_ADMIT_TO_HAVING_HAD_NICKNAMES=1;};
+    NO_NICK_STATUS noNickStatus = 4;
+    string nickName      = 5;
+}

--- a/src/generator/generatorbase.h
+++ b/src/generator/generatorbase.h
@@ -100,6 +100,7 @@ namespace generator {
  * \param QML Enables QML code generation in protobuf classes. If provided in parameter list QML related code for lists and QML registration to be generated.
  * \param COMMENTS Enables comments copying from .proto files. If provided in parameter list message and field related comments will be copied to generated header files.
  * \param FOLDER Enables folder based generation. If provided in parameter list generator will place generated artifacts to folder structure according to package of corresponding .proto file
+ * \param FIELDENUM Enables generation of field numbers as an enum within the message class.
  *
  * \subsection cmake_qtprotobuf_link_target qtprotobuf_link_target
  *


### PR DESCRIPTION
Truth be told, the .pro file is incomplete, but if you manually invoke protoc something like this:
  QT_PROTOBUF_OPTIONS="FIELDENUM" protoc --plugin=protoc-gen-qtprotobuf=/usr/local/bin/qtprotobufgen --qtprotobuf_out=. field_enum_example.proto
then it will compile.