### PR TITLE
Add reflection of the json name to the property ordering

### DIFF
--- a/src/generator/messagedefinitionprinter.cpp
+++ b/src/generator/messagedefinitionprinter.cpp
@@ -99,7 +99,8 @@ void MessageDefinitionPrinter::printFieldsOrdering() {
         //property_number is incremented by 1 because user properties stating from 1.
         //Property with index 0 is "objectName"
         mPrinter->Print({{"field_number", std::to_string(field->number())},
-                         {"property_number", std::to_string(i + 1)}}, Templates::FieldOrderTemplate);
+                         {"property_number", std::to_string(i + 1)},
+                         {"json_name", field->json_name()}}, Templates::FieldOrderTemplate);
     }
     Outdent();
     mPrinter->Print(Templates::SemicolonBlockEnclosureTemplate);

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -242,7 +242,7 @@ const char *Templates::SignalTemplate = "void $property_name$Changed();\n";
 
 const char *Templates::FieldsOrderingContainerTemplate = "const QtProtobuf::QProtobufMetaObject $type$::protobufMetaObject = QtProtobuf::QProtobufMetaObject($type$::staticMetaObject, $type$::propertyOrdering);\n"
                                                          "const QtProtobuf::QProtobufPropertyOrdering $type$::propertyOrdering = {";
-const char *Templates::FieldOrderTemplate = "{$field_number$, $property_number$}";
+const char *Templates::FieldOrderTemplate = "{$field_number$, {$property_number$, \"$json_name$\"}}";
 
 const char *Templates::EnumTemplate = "$type$";
 

--- a/src/protobuf/qprotobufmetaproperty.cpp
+++ b/src/protobuf/qprotobufmetaproperty.cpp
@@ -26,44 +26,22 @@
 #include "qprotobufmetaproperty.h"
 #include "qtprotobuftypes.h"
 
-#include <string>
-
-//TODO: Code under unnamed namespace should be moved to the common header that is relevant for generator and metaproperty
-namespace  {
-int constexpr constexpr_strlen(const char* str)
-{
-    return *str ? 1 + constexpr_strlen(str + 1) : 0;
-}
-const std::vector<std::string> ListOfQmlExeptions{"id", "property", "import"};
-constexpr const char *privateSuffix = "_p";
-constexpr const char *protoSuffix = "_proto";
-constexpr int privateSuffixLenght = constexpr_strlen(privateSuffix);
-constexpr int protoSuffixLenght = constexpr_strlen(protoSuffix);
-}
-
 using namespace QtProtobuf;
-QProtobufMetaProperty::QProtobufMetaProperty(const QMetaProperty &metaProperty, int fieldIndex) : QMetaProperty(metaProperty)
+QProtobufMetaProperty::QProtobufMetaProperty(const QMetaProperty &metaProperty,
+                                             int fieldIndex,
+                                             const QString &jsonName) : QMetaProperty(metaProperty)
   , m_fieldIndex(fieldIndex)
+  , m_jsonName(jsonName)
 {
 
 }
 
-QString QProtobufMetaProperty::protoPropertyName() const
+int QProtobufMetaProperty::protoFieldIndex() const
 {
-    QString protoName(name());
-    if ((userType() == qMetaTypeId<QtProtobuf::int32>()
-            || userType() == qMetaTypeId<QtProtobuf::fixed32>()
-            || userType() == qMetaTypeId<QtProtobuf::sfixed32>())
-            && protoName.endsWith(privateSuffix)) {
-        return protoName.mid(0, protoName.size() - privateSuffixLenght);
-    }
+    return m_fieldIndex;
+}
 
-    if (protoName.endsWith(protoSuffix)) {
-        auto tmpProtoName = protoName.mid(0, protoName.size() - protoSuffixLenght);
-        if (std::find(ListOfQmlExeptions.begin(), ListOfQmlExeptions.end(), protoName.toStdString()) != ListOfQmlExeptions.end()) {
-            return tmpProtoName;
-        }
-    }
-
-    return protoName;
+QString QProtobufMetaProperty::jsonPropertyName() const
+{
+    return m_jsonName;
 }

--- a/src/protobuf/qprotobufmetaproperty.h
+++ b/src/protobuf/qprotobufmetaproperty.h
@@ -35,15 +35,18 @@ namespace QtProtobuf {
  * \private
  * \brief The QProtobufMetaProperty class
  */
+struct PropertyOrderingInfo;
+
 class Q_PROTOBUF_EXPORT QProtobufMetaProperty : public QMetaProperty
 {
 public:
-    QProtobufMetaProperty(const QMetaProperty &, int fieldIndex);
-    int protoFieldIndex() const { return m_fieldIndex; }
-    QString protoPropertyName() const;
+    QProtobufMetaProperty(const QMetaProperty &, int fieldIndex, const QString &jsonName);
+    int protoFieldIndex() const;
+    QString jsonPropertyName() const;
 private:
     QProtobufMetaProperty();
-    int m_fieldIndex;
+    const int m_fieldIndex;
+    const QString &m_jsonName;
 };
 
 }

--- a/src/protobuf/qprotobufserializer.cpp
+++ b/src/protobuf/qprotobufserializer.cpp
@@ -88,7 +88,9 @@ QByteArray QProtobufSerializer::serializeMessage(const QObject *object, const QP
         QMetaProperty metaProperty = metaObject.staticMetaObject.property(propertyIndex);
         const char *propertyName = metaProperty.name();
         QVariant propertyValue = object->property(propertyName);
-        result.append(dPtr->serializeProperty(propertyValue, QProtobufMetaProperty(metaProperty, fieldIndex)));
+        result.append(dPtr->serializeProperty(propertyValue, QProtobufMetaProperty(metaProperty,
+                                                                                   fieldIndex,
+                                                                                   field.second)));
     }
 
     return result;
@@ -128,7 +130,9 @@ bool QProtobufSerializer::deserializeListObject(QObject *object, const QProtobuf
 QByteArray QProtobufSerializer::serializeMapPair(const QVariant &key, const QVariant &value, const QProtobufMetaProperty &metaProperty) const
 {
     QByteArray result = QProtobufSerializerPrivate::encodeHeader(metaProperty.protoFieldIndex(), LengthDelimited);
-    result.append(QProtobufSerializerPrivate::prependLengthDelimitedSize(dPtr->serializeProperty(key, QProtobufMetaProperty(metaProperty, 1)) + dPtr->serializeProperty(value, QProtobufMetaProperty(metaProperty, 2))));
+    result.append(QProtobufSerializerPrivate::prependLengthDelimitedSize(
+                      dPtr->serializeProperty(key, QProtobufMetaProperty(metaProperty, 1, QString())) +
+                      dPtr->serializeProperty(value, QProtobufMetaProperty(metaProperty, 2, QString()))));
     return result;
 }
 
@@ -273,7 +277,7 @@ QByteArray QProtobufSerializerPrivate::serializeProperty(const QVariant &propert
         }
     } else {
         auto handler = QtProtobufPrivate::findHandler(userType);
-        handler.serializer(q_ptr, propertyValue, QProtobufMetaProperty(metaProperty, metaProperty.protoFieldIndex()), result);
+        handler.serializer(q_ptr, propertyValue, metaProperty, result);
     }
     return result;
 }

--- a/src/protobuf/qtprotobuftypes.h
+++ b/src/protobuf/qtprotobuftypes.h
@@ -33,6 +33,7 @@
 #include <unordered_map>
 #include <functional>
 #include <list>
+#include <type_traits>
 
 namespace QtProtobuf {
 
@@ -54,7 +55,26 @@ enum WireTypes {
 };
 
 //! \private
-using QProtobufPropertyOrdering = std::unordered_map<int, int>;
+struct PropertyOrderingInfo {
+    PropertyOrderingInfo(int _qtProperty, const QString &_jsonName) : qtProperty(_qtProperty)
+      , jsonName(_jsonName) {}
+
+    int qtProperty;
+    QString jsonName;
+    template<typename T,
+             typename std::enable_if_t<std::is_integral<T>::value, int> = 0>
+    operator T() const { return qtProperty; }
+    operator QString() const { return jsonName; }
+
+    template<typename T,
+             typename std::enable_if_t<std::is_integral<T>::value, int> = 0>
+    bool operator==(const T _qtProperty) const { return _qtProperty == qtProperty; }
+    bool operator==(const QString &_jsonName) const { return _jsonName == jsonName; }
+};
+
+//! \private
+//!
+using QProtobufPropertyOrdering = std::unordered_map<int, PropertyOrderingInfo>;
 
 /*!
  * \private

--- a/tests/testscommon.h
+++ b/tests/testscommon.h
@@ -37,7 +37,7 @@ static void assertMessagePropertyRegistered(int fieldIndex, const char *property
 {
     // TODO: there should be(?) a mapping avaialble: PropertyType -> propertyTypeName
 
-    const int propertyNumber = MessageType::propertyOrdering.at(fieldIndex);
+    const int propertyNumber = MessageType::propertyOrdering.at(fieldIndex).qtProperty;
     ASSERT_STREQ(MessageType::staticMetaObject.property(propertyNumber).typeName(), propertyTypeName);
     if (!skipMetatypeCheck) {
         ASSERT_EQ(MessageType::staticMetaObject.property(propertyNumber).userType(), qMetaTypeId<PropertyType>());


### PR DESCRIPTION
- Current approach of mapping property names is not fully
  compatible with JSON serializing. This causes many design
  issues especially with the field aliases. So the explicit JSON
  reflection is the only suitable solution for this.
- Update tests.