### PR TITLE
Make the protobuf package optional

### DIFF
--- a/src/generator/parsemessages.go
+++ b/src/generator/parsemessages.go
@@ -62,11 +62,14 @@ func main() {
 		}
 	}
 
+	newoffset, err := file.Seek(0, 0)
+	if err != nil || newoffset != 0 {
+		log.Fatal(err)
+	}
+	scanner = bufio.NewScanner(file)
+
 	if multi {
 		for scanner.Scan() {
-			if fullpath == "" {
-				log.Fatalf("Package is not specified correctly in %s file\n", os.Args[1])
-			}
 			capture := messageFinder.FindStringSubmatch(scanner.Text())
 			if len(capture) == 2 {
 				fmt.Printf("%s%s.h;", fullpath, strings.ToLower(capture[1]))
@@ -78,9 +81,6 @@ func main() {
 			}
 		}
 	} else {
-		if folder && fullpath == "" {
-			log.Fatalf("Package is not specified correctly in %s file\n", os.Args[1])
-		}
 		//Singlefile version
 		enumFinder, err := regexp.Compile("^enum\\s+([a-zA-Z0-9_]+)")
 		if err != nil {

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -371,8 +371,8 @@ const char *Templates::RegisterSerializersTemplate = "qRegisterProtobufType<$cla
 const char *Templates::RegisterEnumSerializersTemplate = "qRegisterProtobufEnumType<$full_type$>();\n";
 const char *Templates::RegistrarTemplate = "static QtProtobuf::ProtoTypeRegistrar<$classname$> ProtoTypeRegistrar$classname$(qRegisterProtobufType<$classname$>);\n";
 const char *Templates::EnumRegistrarTemplate = "static QtProtobuf::ProtoTypeRegistrar<$enum_gadget$> ProtoTypeRegistrar$enum_gadget$($enum_gadget$::registerTypes);\n";
-const char *Templates::QmlRegisterTypeTemplate = "qmlRegisterType<$scope_type$>(\"$qml_package$\", 1, 0, \"$type$\");\n";
-const char *Templates::QmlRegisterEnumTypeTemplate = "qmlRegisterUncreatableType<$enum_gadget$>(\"$qml_package$\", 1, 0, \"$type$\", \"$full_type$ Could not be created from qml context\");\n";
+const char *Templates::QmlRegisterTypeTemplate = "Q_ASSERT(qmlRegisterType<$scope_type$>(\"$qml_package$\", 1, 0, \"$type$\") >= 0);\n";
+const char *Templates::QmlRegisterEnumTypeTemplate = "Q_ASSERT(qmlRegisterUncreatableType<$enum_gadget$>(\"$qml_package$\", 1, 0, \"$type$\", \"$full_type$ Could not be created from qml context\") >= 0);\n";
 
 
 const char *Templates::ClientMethodSignalDeclarationTemplate = "Q_SIGNAL void $method_name$Updated(const $return_type$ &);\n";

--- a/tests/test_protobuf/deserializationtest.cpp
+++ b/tests/test_protobuf/deserializationtest.cpp
@@ -286,7 +286,7 @@ TEST_F(DeserializationTest, DoubleMessageDeserializeTest)
 
 TEST_F(DeserializationTest, IntMessageDeserializeTest)
 {
-    SimpleIntMessage test;
+    qtprotobufnamespace::tests::SimpleIntMessage test;
     test.deserialize(serializer.get(), QByteArray::fromHex("080f"));
     ASSERT_EQ(15, test.testFieldInt());
 

--- a/tests/test_protobuf/jsondeserializationtest.cpp
+++ b/tests/test_protobuf/jsondeserializationtest.cpp
@@ -87,7 +87,7 @@ TEST_F(JsonDeserializationTest, SFixedInt32MessageSerializeTest)
 
 TEST_F(JsonDeserializationTest, Int32MessageSerializeTest)
 {
-    SimpleIntMessage msg;
+    qtprotobufnamespace::tests::SimpleIntMessage msg;
     msg.deserialize(serializer.get(), QByteArray("{\"testFieldInt\":555}"));
     EXPECT_EQ(msg.testFieldInt(), 555);
 }

--- a/tests/test_protobuf/jsonserializationtest.cpp
+++ b/tests/test_protobuf/jsonserializationtest.cpp
@@ -75,7 +75,7 @@ TEST_F(JsonSerializationTest, SFixedInt32MessageSerializeTest)
 
 TEST_F(JsonSerializationTest, Int32MessageSerializeTest)
 {
-    SimpleIntMessage msg;
+    qtprotobufnamespace::tests::SimpleIntMessage msg;
     msg.setTestFieldInt(555);
     QByteArray result = msg.serialize(serializer.get());
     ASSERT_STREQ(QString::fromUtf8(result).toStdString().c_str(), "{\"testFieldInt\":555}");

--- a/tests/test_protobuf/proto/nopackage.proto
+++ b/tests/test_protobuf/proto/nopackage.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+import "nopackageexternal.proto";
+
+message EmptyMessage {
+}
+
+enum TestEnum {
+    LOCAL_ENUM_VALUE0 = 0;
+    LOCAL_ENUM_VALUE1 = 1;
+    LOCAL_ENUM_VALUE2 = 2;
+    LOCAL_ENUM_VALUE3 = 5;
+}
+
+message SimpleIntMessage {
+    int32 testFieldInt = 1;
+}
+
+message NoPackageExternalMessage {
+    SimpleIntMessageExt testField = 1;
+}

--- a/tests/test_protobuf/proto/nopackageexternal.proto
+++ b/tests/test_protobuf/proto/nopackageexternal.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message SimpleIntMessageExt {
+    int32 testFieldInt = 1;
+}

--- a/tests/test_protobuf/proto/simpletest.proto
+++ b/tests/test_protobuf/proto/simpletest.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "externalpackagetest.proto";
+import "nopackageexternal.proto";
 
 package qtprotobufnamespace.tests;
 
@@ -630,3 +631,6 @@ message LowerCaseFieldMessageName {
     lowerCaseMessageName testField = 1;
 }
 
+message NoPackageMessage {
+    SimpleIntMessageExt testField = 1;
+}

--- a/tests/test_protobuf/serializationtest.cpp
+++ b/tests/test_protobuf/serializationtest.cpp
@@ -45,7 +45,7 @@ void SerializationTest::SetUp()
 
 TEST_F(SerializationTest, IntMessageSerializeTest)
 {
-    SimpleIntMessage test;
+    qtprotobufnamespace::tests::SimpleIntMessage test;
     test.setTestFieldInt(15);
     QByteArray result = test.serialize(serializer.get());
     ASSERT_EQ(result.size(), 2);
@@ -1304,7 +1304,7 @@ TEST_F(SerializationTest, EmptyStringMessageTest)
 
 TEST_F(SerializationTest, DISABLED_BenchmarkTest)
 {
-    SimpleIntMessage msg;
+    qtprotobufnamespace::tests::SimpleIntMessage msg;
     for (int i = INT16_MIN; i < INT16_MAX; i++) {
         msg.setTestFieldInt(i);
         msg.serialize(serializer.get());

--- a/tests/test_protobuf/simpletest.cpp
+++ b/tests/test_protobuf/simpletest.cpp
@@ -28,5 +28,6 @@
 #include "externalpackagetest.qpb.h"
 #include "globalenums.qpb.h"
 #include "globalenumssamenamespace.qpb.h"
+#include "nopackage.qpb.h"
 
 #include "./simpletest.cpp.inc"

--- a/tests/test_protobuf/simpletest.cpp.inc
+++ b/tests/test_protobuf/simpletest.cpp.inc
@@ -67,14 +67,14 @@ TEST_F(SimpleTest, SimpleBoolMessageTest)
 TEST_F(SimpleTest, SimpleIntMessageTest)
 {
     const char *propertyName = "testFieldInt_p";
-    assertMessagePropertyRegistered<SimpleIntMessage, int32>(1, "QtProtobuf::int32", propertyName);
+    assertMessagePropertyRegistered<qtprotobufnamespace::tests::SimpleIntMessage, int32>(1, "QtProtobuf::int32", propertyName);
 
-    SimpleIntMessage test;
+    qtprotobufnamespace::tests::SimpleIntMessage test;
     ASSERT_TRUE(test.setProperty(propertyName, QVariant::fromValue<int32>(1)));
     ASSERT_EQ(test.property(propertyName).value<int32>(), 1);
     ASSERT_EQ(test.testFieldInt(), 1);
 
-    EXPECT_EQ(SimpleIntMessage::TestFieldIntProtoFieldNumber, 1);
+    EXPECT_EQ(qtprotobufnamespace::tests::SimpleIntMessage::TestFieldIntProtoFieldNumber, 1);
 }
 
 TEST_F(SimpleTest, SimpleSIntMessageTest)
@@ -296,10 +296,10 @@ TEST_F(SimpleTest, SimpleExternalEnumMessageTest)
 
 TEST_F(SimpleTest, SimpleEnumsTest)
 {
-    EXPECT_GT(TestEnumGadget::staticMetaObject.enumeratorCount(), 0);
+    EXPECT_GT(qtprotobufnamespace::tests::TestEnumGadget::staticMetaObject.enumeratorCount(), 0);
     QMetaEnum testEnum;
-    for (int i = 0; i < TestEnumGadget::staticMetaObject.enumeratorCount(); i++) {
-        QMetaEnum tmp = TestEnumGadget::staticMetaObject.enumerator(i);
+    for (int i = 0; i < qtprotobufnamespace::tests::TestEnumGadget::staticMetaObject.enumeratorCount(); i++) {
+        QMetaEnum tmp = qtprotobufnamespace::tests::TestEnumGadget::staticMetaObject.enumerator(i);
         if (QString(tmp.name()) == QString("TestEnum")) {
             testEnum = tmp;
             break;
@@ -339,16 +339,16 @@ TEST_F(SimpleTest, SimpleEnumsTest)
 TEST_F(SimpleTest, SimpleFileEnumsTest)
 {
     const char *propertyName = "globalEnumListData";
-    assertMessagePropertyRegistered<SimpleFileEnumMessage, TestEnumGadget::TestEnumRepeated>(2, "qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated", propertyName);
+    assertMessagePropertyRegistered<SimpleFileEnumMessage, qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated>(2, "qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated", propertyName);
 
-    TestEnumGadget::TestEnumRepeated value{TestEnumGadget::TEST_ENUM_VALUE1,
-                                     TestEnumGadget::TEST_ENUM_VALUE3,
-                                     TestEnumGadget::TEST_ENUM_VALUE4,
-                                     TestEnumGadget::TEST_ENUM_VALUE2,
-                                     TestEnumGadget::TEST_ENUM_VALUE1};
+    qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated value{qtprotobufnamespace::tests::TestEnumGadget::TEST_ENUM_VALUE1,
+                                     qtprotobufnamespace::tests::TestEnumGadget::TEST_ENUM_VALUE3,
+                                     qtprotobufnamespace::tests::TestEnumGadget::TEST_ENUM_VALUE4,
+                                     qtprotobufnamespace::tests::TestEnumGadget::TEST_ENUM_VALUE2,
+                                     qtprotobufnamespace::tests::TestEnumGadget::TEST_ENUM_VALUE1};
     SimpleFileEnumMessage test;
-    ASSERT_TRUE(test.setProperty(propertyName, QVariant::fromValue<TestEnumGadget::TestEnumRepeated>(value)));
-    ASSERT_TRUE(test.property(propertyName).value<TestEnumGadget::TestEnumRepeated>() == value);
+    ASSERT_TRUE(test.setProperty(propertyName, QVariant::fromValue<qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated>(value)));
+    ASSERT_TRUE(test.property(propertyName).value<qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated>() == value);
     ASSERT_TRUE(test.globalEnumList() == value);
 }
 
@@ -722,17 +722,17 @@ TEST_F(SimpleTest, SimpleStringStringMapMessageTest)
 
 TEST_F(SimpleTest, EmptyMessageTest)
 {
-    ASSERT_EQ(EmptyMessage::propertyOrdering.size(), 0);
-    ASSERT_EQ(EmptyMessage::staticMetaObject.propertyCount(), 1);
+    ASSERT_EQ(qtprotobufnamespace::tests::EmptyMessage::propertyOrdering.size(), 0);
+    ASSERT_EQ(qtprotobufnamespace::tests::EmptyMessage::staticMetaObject.propertyCount(), 1);
 }
 
 TEST_F(SimpleTest, AssignmentOperatorTest)
 {
     const char *propertyName = "testFieldInt";
-    SimpleIntMessage test;
-    SimpleIntMessage test2{35};
+    qtprotobufnamespace::tests::SimpleIntMessage test;
+    qtprotobufnamespace::tests::SimpleIntMessage test2{35};
 
-    QSignalSpy updateSpy(&test, &SimpleIntMessage::testFieldIntChanged);
+    QSignalSpy updateSpy(&test, &qtprotobufnamespace::tests::SimpleIntMessage::testFieldIntChanged);
     test.setProperty(propertyName, QVariant::fromValue<int32>(15));
     test.setTestFieldInt(25);
     test = test2;
@@ -745,13 +745,13 @@ TEST_F(SimpleTest, AssignmentOperatorTest)
 TEST_F(SimpleTest, MoveOperatorTest)
 {
     const char *propertyName = "testFieldInt";
-    SimpleIntMessage test;
-    SimpleIntMessage test2{35};
+    qtprotobufnamespace::tests::SimpleIntMessage test;
+    qtprotobufnamespace::tests::SimpleIntMessage test2{35};
 
-    QSignalSpy updateSpy(&test, &SimpleIntMessage::testFieldIntChanged);
-    QSignalSpy movedUpdateSpy(&test2, &SimpleIntMessage::testFieldIntChanged);
+    QSignalSpy updateSpy(&test, &qtprotobufnamespace::tests::SimpleIntMessage::testFieldIntChanged);
+    QSignalSpy movedUpdateSpy(&test2, &qtprotobufnamespace::tests::SimpleIntMessage::testFieldIntChanged);
 
-    SimpleIntMessage test3(std::move(test2));
+    qtprotobufnamespace::tests::SimpleIntMessage test3(std::move(test2));
     test2.setTestFieldInt(35);
 
     test.setProperty(propertyName, QVariant::fromValue<int32>(15));
@@ -880,5 +880,70 @@ TEST_F(SimpleTest, MapRepeatedFieldSequenceTest)
     assertMessagePropertyRegistered<sequence::MapFieldSequence, sequence::MapFieldSequence::TestFieldEntry>(1, "qtprotobufnamespace::tests::sequence::MapFieldSequence::TestFieldEntry", "testField");
 }
 
+TEST_F(SimpleTest, NoPackageEmptyMessageMessageTest)
+{
+    ASSERT_EQ(::EmptyMessage::propertyOrdering.size(), 0);
+    ASSERT_EQ(::EmptyMessage::staticMetaObject.propertyCount(), 1);
+}
+
+TEST_F(SimpleTest, NoPackageSimpleIntMessageTest)
+{
+    const char *propertyName = "testFieldInt_p";
+    assertMessagePropertyRegistered<::SimpleIntMessage, int32>(1, "QtProtobuf::int32", propertyName);
+
+    ::SimpleIntMessage test;
+    ASSERT_TRUE(test.setProperty(propertyName, QVariant::fromValue<int32>(1)));
+    ASSERT_EQ(test.property(propertyName).value<int32>(), 1);
+    ASSERT_EQ(test.testFieldInt(), 1);
+
+    EXPECT_EQ(::SimpleIntMessage::TestFieldIntProtoFieldNumber, 1);
+}
+
+TEST_F(SimpleTest, NoPackageEnumTest)
+{
+    EXPECT_GT(::TestEnumGadget::staticMetaObject.enumeratorCount(), 0);
+    QMetaEnum testEnum;
+    for (int i = 0; i < ::TestEnumGadget::staticMetaObject.enumeratorCount(); i++) {
+        QMetaEnum tmp = ::TestEnumGadget::staticMetaObject.enumerator(i);
+        if (QString(tmp.name()) == QString("TestEnum")) {
+            testEnum = tmp;
+            break;
+        }
+    }
+    ASSERT_EQ(testEnum.keyCount(), 4);
+    EXPECT_TRUE(testEnum.isValid());
+    EXPECT_STREQ(testEnum.key(0), "LOCAL_ENUM_VALUE0");
+    EXPECT_STREQ(testEnum.key(1), "LOCAL_ENUM_VALUE1");
+    EXPECT_STREQ(testEnum.key(2), "LOCAL_ENUM_VALUE2");
+    EXPECT_STREQ(testEnum.key(3), "LOCAL_ENUM_VALUE3");
+
+    EXPECT_EQ(testEnum.value(0), 0);
+    EXPECT_EQ(testEnum.value(1), 1);
+    EXPECT_EQ(testEnum.value(2), 2);
+    EXPECT_EQ(testEnum.value(3), 5);
+}
+
+TEST_F(SimpleTest, NoPackageExternalTest)
+{
+    const char *propertyName = "testField";
+    assertMessagePropertyRegistered<NoPackageExternalMessage, SimpleIntMessageExt*>(1, "SimpleIntMessageExt*", propertyName);
+
+    NoPackageExternalMessage test;
+    ASSERT_TRUE(test.setProperty(propertyName, QVariant::fromValue<SimpleIntMessageExt*>(new SimpleIntMessageExt{42})));
+    ASSERT_EQ(test.property(propertyName).value<SimpleIntMessageExt*>()->testFieldInt(), 42);
+    ASSERT_EQ(test.testField().testFieldInt(), 42);
+}
+
+
+TEST_F(SimpleTest, NoPackageMessageTest)
+{
+    const char *propertyName = "testField";
+    assertMessagePropertyRegistered<NoPackageMessage, SimpleIntMessageExt*>(1, "SimpleIntMessageExt*", propertyName);
+
+    NoPackageMessage test;
+    ASSERT_TRUE(test.setProperty(propertyName, QVariant::fromValue<SimpleIntMessageExt*>(new SimpleIntMessageExt{42})));
+    ASSERT_EQ(test.property(propertyName).value<SimpleIntMessageExt*>()->testFieldInt(), 42);
+    ASSERT_EQ(test.testField().testFieldInt(), 42);
+}
 } // tests
 } // qtprotobuf

--- a/tests/test_protobuf_multifile/simpletest.cpp
+++ b/tests/test_protobuf_multifile/simpletest.cpp
@@ -86,6 +86,10 @@
 #include "qtprotobufnamespace/tests/lowercasemessagename.h"
 #include "qtprotobufnamespace/tests/lowercasefieldmessagename.h"
 #include "qtprotobufnamespace/tests/messageuppercase.h"
+#include "emptymessage.h"
+#include "simpleintmessage.h"
+#include "nopackageexternalmessage.h"
+#include "qtprotobufnamespace/tests/nopackagemessage.h"
 
 #include "globalenums.h"
 

--- a/tests/test_qml/qml/tst_simple.qml
+++ b/tests/test_qml/qml/tst_simple.qml
@@ -101,6 +101,11 @@ TestCase {
         testFieldInt: 100
     }
 
+    NoPackageMessage {
+        id: noPackageMessageUser
+        testField.testFieldInt: 42
+    }
+
     function test_1initialization() {
         compare(int32Msg.testFieldInt, 2147483647, "SimpleIntMessage initialization")
         compare(sint32Msg.testFieldInt, 2147483647, "SimpleSIntMessage initialization")
@@ -331,5 +336,11 @@ TestCase {
     function test_nestedMessage() {
         compare(nestedMsg.testFieldInt, 100, "Nested message initialization failed");
         compare(nestedParent.nested, nestedMsg, "Nested message assignment failed");
+    }
+
+    function test_noPackageMessageUser() {
+        compare(noPackageMessageUser.testField.testFieldInt, 42, "Package-less message contains invalid value");
+        noPackageMessageUser.testField.testFieldInt = 43;
+        compare(noPackageMessageUser.testField.testFieldInt, 43, "Package-less message contains invalid value");
     }
 }


### PR DESCRIPTION
- protobuf does not require the package to be specified in the
  .proto file. Remove the associated checks from the
  parsemessages.go script to continue generating messages
  without the specified package.
- Add and update tests

Fixes: #192