### PR TITLE
Fix installation rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,3 +146,5 @@ if(QT_PROTOBUF_INSTALL)
     include(packaging)
 endif()
 include(doxygen)
+
+qt_protobuf_internal_install_targets()

--- a/cmake/QtProtobufGen.cmake
+++ b/cmake/QtProtobufGen.cmake
@@ -120,7 +120,7 @@ function(qtprotobuf_generate)
         endif()
     endforeach()
 
-    set_source_files_properties(${GENERATED_SOURCES_FULL} PROPERTIES
+    set_source_files_properties(${GENERATED_SOURCES_FULL};${GENERATED_HEADERS_FULL} PROPERTIES
         GENERATED TRUE
         SKIP_AUTOMOC ON
         SKIP_AUTOUIC ON
@@ -148,6 +148,9 @@ function(qtprotobuf_generate)
 
     add_library(${GENERATED_TARGET_NAME} OBJECT ${GENERATED_SOURCES_FULL} ${MOC_SOURCES})
     add_dependencies(${GENERATED_TARGET_NAME} ${deps_target})
+    if(qtprotobuf_generate_TARGET)
+        set_property(TARGET ${qtprotobuf_generate_TARGET} APPEND PROPERTY PUBLIC_HEADER ${GENERATED_HEADERS_FULL})
+    endif()
     set_target_properties(${GENERATED_TARGET_NAME} PROPERTIES PUBLIC_HEADER "${GENERATED_HEADERS_FULL}")
 
     #Add include directories in case if targets are found by find_project or in source tree

--- a/src/qttypes/CMakeLists.txt
+++ b/src/qttypes/CMakeLists.txt
@@ -1,9 +1,13 @@
+set(qttypes_install_includedir ${CMAKE_INSTALL_INCLUDEDIR}/QtProtobuf)
+
 qt_protobuf_internal_add_library(ProtobufQtTypes
     SOURCES
         qtprotobufqttypes.cpp
     PUBLIC_HEADER
         qtprotobufqttypes.h
         qtprotobufqttypesglobal.h
+    INSTALL_INCLUDEDIR
+        "${qttypes_install_includedir}"
     PUBLIC_INCLUDE_DIRECTORIES
         "$<BUILD_INTERFACE:${QT_PROTOBUF_BINARY_DIR}/include/QtProtobuf>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
@@ -14,7 +18,6 @@ qt_protobuf_internal_add_library(ProtobufQtTypes
         ${QT_PROTOBUF_NAMESPACE}::Protobuf
 )
 
-set(INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/QtProtobuf)
 
 file(GLOB PROTO_FILE ${CMAKE_CURRENT_SOURCE_DIR}/QtProtobuf/Qt*.proto)
 qtprotobuf_generate(TARGET ProtobufQtTypes
@@ -26,16 +29,17 @@ target_compile_definitions(ProtobufQtTypes PRIVATE QT_BUILD_PROTOBUF_QT_TYPES_LI
 
 set_target_properties(ProtobufQtTypes PROPERTIES
     PROTO_INCLUDES
-        "-I\"${CMAKE_CURRENT_SOURCE_DIR}\";-I\"${CMAKE_INSTALL_PREFIX}/${INSTALL_INCLUDEDIR}\""
+        "-I\"${CMAKE_CURRENT_SOURCE_DIR}\";\
+-I\"${CMAKE_INSTALL_PREFIX}/${qttypes_install_includedir}\""
 )
 
 set_property(TARGET ProtobufQtTypes APPEND PROPERTY EXPORT_PROPERTIES PROTO_INCLUDES)
 
 if(QT_PROTOBUF_INSTALL)
     install(FILES
-                "${CMAKE_CURRENT_SOURCE_DIR}/QtProtobuf/QtCore.proto"
-                "${CMAKE_CURRENT_SOURCE_DIR}/QtProtobuf/QtGui.proto"
-            DESTINATION "${INSTALL_INCLUDEDIR}"
-            COMPONENT dev
+            "${CMAKE_CURRENT_SOURCE_DIR}/QtProtobuf/QtCore.proto"
+            "${CMAKE_CURRENT_SOURCE_DIR}/QtProtobuf/QtGui.proto"
+        DESTINATION "${qttypes_install_includedir}"
+        COMPONENT dev
     )
 endif()

--- a/src/wellknowntypes/CMakeLists.txt
+++ b/src/wellknowntypes/CMakeLists.txt
@@ -1,36 +1,41 @@
 qt_protobuf_internal_add_library(ProtobufWellKnownTypes
     SOURCES
         dummy.cpp
+    INSTALL_INCLUDEDIR
+         "${CMAKE_INSTALL_INCLUDEDIR}/QtProtobuf/google/protobuf"
     PUBLIC_INCLUDE_DIRECTORIES
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/QtProtobuf/google/protobuf>"
     PUBLIC_LIBRARIES
         Qt5::Core
         Qt5::Qml
         ${QT_PROTOBUF_NAMESPACE}::Protobuf
 )
 
-function(add_wellknowntype TYPENAME)
-    list(APPEND LOOKUP_DIRS ${QT_PROTOBUF_SOURCE_DIR}/3rdparty/grpc/third_party/protobuf/src)
-    list(APPEND LOOKUP_DIRS ${Protobuf_INCLUDE_DIRS})
-    foreach(INCLUDE_DIR ${LOOKUP_DIRS})
-        file(GLOB PROTO_FILE ${INCLUDE_DIR}/google/protobuf/${TYPENAME}.proto)
+function(add_wellknowntype type_name)
+    set(lookup_dirs "${QT_PROTOBUF_SOURCE_DIR}/3rdparty/grpc/third_party/protobuf/src"
+        ${Protobuf_INCLUDE_DIRS}
+    )
+    foreach(dir ${lookup_dirs})
+        file(GLOB PROTO_FILE "${dir}/google/protobuf/${type_name}.proto")
         if(NOT "${PROTO_FILE}" STREQUAL "")
             message(STATUS "Add well-known type ${PROTO_FILE}")
-            qtprotobuf_generate(TARGET ProtobufWellKnownTypes GENERATED_TARGET ${TYPENAME}
-                OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
-                PROTO_FILES ${PROTO_FILE}
-                PROTO_INCLUDES "-I\"${INCLUDE_DIR}\""
-                QML FOLDER ${extra_type_libraries_options})
-            target_include_directories(${TYPENAME} PRIVATE
-                $<TARGET_PROPERTY:${QT_PROTOBUF_NAMESPACE}::ProtobufWellKnownTypes,INTERFACE_INCLUDE_DIRECTORIES>)
-            get_target_property(GENERATED_PUBLIC_HEADER_PRIVATE ${TYPENAME} PUBLIC_HEADER)
-            set(GENERATED_PUBLIC_HEADER "${GENERATED_PUBLIC_HEADER};${GENERATED_PUBLIC_HEADER_PRIVATE}" PARENT_SCOPE)
+            qtprotobuf_generate(TARGET ProtobufWellKnownTypes
+                GENERATED_TARGET ${type_name}
+                OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated"
+                PROTO_FILES "${PROTO_FILE}"
+                PROTO_INCLUDES "-I\"${dir}\""
+                QML
+                FOLDER
+                ${extra_type_libraries_options}
+            )
+            target_include_directories(${type_name} PRIVATE
+                "$<TARGET_PROPERTY:ProtobufWellKnownTypes,INTERFACE_INCLUDE_DIRECTORIES>"
+            )
             break()
         endif()
     endforeach()
-    if(NOT TARGET ${TYPENAME})
-        message(FATAL_ERROR "Unable to add well-know type ${TYPENAME}")
+    if(NOT TARGET ${type_name})
+        message(FATAL_ERROR "Unable to add well-know type ${type_name}")
     endif()
 endfunction()
 


### PR DESCRIPTION
- Add support of the custom install paths for the add_*
  functions.
- Move installation rules to the end of the project, to make sure
  that the generated headers are included to the PUBLIC_HEADER
  set of the target.
- Add the generated headers to the target if it's specified in
  qtprotobuf_generate function call.

Fixes: #197