### PR TITLE
Fix couple regressions

### DIFF
--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -371,8 +371,8 @@ const char *Templates::RegisterSerializersTemplate = "qRegisterProtobufType<$cla
 const char *Templates::RegisterEnumSerializersTemplate = "qRegisterProtobufEnumType<$full_type$>();\n";
 const char *Templates::RegistrarTemplate = "static QtProtobuf::ProtoTypeRegistrar<$classname$> ProtoTypeRegistrar$classname$(qRegisterProtobufType<$classname$>);\n";
 const char *Templates::EnumRegistrarTemplate = "static QtProtobuf::ProtoTypeRegistrar<$enum_gadget$> ProtoTypeRegistrar$enum_gadget$($enum_gadget$::registerTypes);\n";
-const char *Templates::QmlRegisterTypeTemplate = "Q_ASSERT(qmlRegisterType<$scope_type$>(\"$qml_package$\", 1, 0, \"$type$\") >= 0);\n";
-const char *Templates::QmlRegisterEnumTypeTemplate = "Q_ASSERT(qmlRegisterUncreatableType<$enum_gadget$>(\"$qml_package$\", 1, 0, \"$type$\", \"$full_type$ Could not be created from qml context\") >= 0);\n";
+const char *Templates::QmlRegisterTypeTemplate = "qmlRegisterType<$scope_type$>(\"$qml_package$\", 1, 0, \"$type$\");\n";
+const char *Templates::QmlRegisterEnumTypeTemplate = "qmlRegisterUncreatableType<$enum_gadget$>(\"$qml_package$\", 1, 0, \"$type$\", \"$full_type$ Could not be created from qml context\");\n";
 
 
 const char *Templates::ClientMethodSignalDeclarationTemplate = "Q_SIGNAL void $method_name$Updated(const $return_type$ &);\n";

--- a/src/qttypes/CMakeLists.txt
+++ b/src/qttypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(qttypes_install_includedir ${CMAKE_INSTALL_INCLUDEDIR}/QtProtobuf)
+set(qttypes_install_includedir ${CMAKE_INSTALL_INCLUDEDIR}/${QT_PROTOBUF_NAMESPACE}Protobuf)
 
 qt_protobuf_internal_add_library(ProtobufQtTypes
     SOURCES
@@ -9,7 +9,6 @@ qt_protobuf_internal_add_library(ProtobufQtTypes
     INSTALL_INCLUDEDIR
         "${qttypes_install_includedir}"
     PUBLIC_INCLUDE_DIRECTORIES
-        "$<BUILD_INTERFACE:${QT_PROTOBUF_BINARY_DIR}/include/QtProtobuf>"
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
     PUBLIC_LIBRARIES
         Qt5::Core

--- a/src/wellknowntypes/CMakeLists.txt
+++ b/src/wellknowntypes/CMakeLists.txt
@@ -2,7 +2,7 @@ qt_protobuf_internal_add_library(ProtobufWellKnownTypes
     SOURCES
         dummy.cpp
     INSTALL_INCLUDEDIR
-         "${CMAKE_INSTALL_INCLUDEDIR}/QtProtobuf/google/protobuf"
+         "${CMAKE_INSTALL_INCLUDEDIR}/${QT_PROTOBUF_NAMESPACE}Protobuf/google/protobuf"
     PUBLIC_INCLUDE_DIRECTORIES
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>"
     PUBLIC_LIBRARIES


### PR DESCRIPTION
- Q_ASSERT is expanded to nothing in relase builds so the QML
  type registration is never happen for the release builds.
  Remove redundant Q_ASSERT wrappers.
- Fix the header installtion path of the 'WellKnownTypes' and
  'QtTypes' libraries.

Fixes: #201 #197