### PR TITLE
Split WrapProtobuf module into components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ set(QT_PROTOBUF_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 list(APPEND CMAKE_MODULE_PATH ${QT_PROTOBUF_CMAKE_DIR})
 
-find_package(WrapProtobuf REQUIRED)
 find_package(WrapgRPC)
+find_package(WrapProtobuf COMPONENTS Protoc OPTIONAL_COMPONENTS Generator Protobuf REQUIRED)
 find_package(Threads)
 find_package(${QT_VERSIONED_PREFIX} COMPONENTS Core Qml CONFIG REQUIRED)
 find_package(${QT_VERSIONED_PREFIX} OPTIONAL_COMPONENTS Network Quick Gui CONFIG)
@@ -116,10 +116,10 @@ if(TARGET ${QT_VERSIONED_PREFIX}::Network)
     endif()
 endif()
 
-if(TARGET protobuf::libprotobuf)
+if(TARGET protobuf::libprotobuf AND TARGET protobuf::protoc)
     add_subdirectory("src/wellknowntypes")
 endif()
-if(TARGET ${QT_VERSIONED_PREFIX}::Gui)
+if(TARGET ${QT_VERSIONED_PREFIX}::Gui AND TARGET protobuf::protoc)
     add_subdirectory("src/qttypes")
 endif()
 

--- a/src/generator/QtqtprotobufgenConfig.cmake.in
+++ b/src/generator/QtqtprotobufgenConfig.cmake.in
@@ -1,5 +1,6 @@
 include(CMakeFindDependencyMacro)
-find_dependency(WrapProtobuf REQUIRED)
+# We only look for protoc, libprotoc should already be in rpath or linked statically
+find_package(WrapProtobuf COMPONENTS Generator REQUIRED)
 
 if(NOT TARGET @QT_PROTOBUF_NAMESPACE@::@target@)
     include("${CMAKE_CURRENT_LIST_DIR}/@target_export@.cmake")

--- a/src/wellknowntypes/QtProtobufWellKnownTypesConfig.cmake.in
+++ b/src/wellknowntypes/QtProtobufWellKnownTypesConfig.cmake.in
@@ -1,5 +1,5 @@
 include(CMakeFindDependencyMacro)
-find_dependency(WrapProtobuf REQUIRED)
+find_dependency(WrapProtobuf COMPONENTS Protobuf REQUIRED)
 
 if(NOT TARGET @QT_PROTOBUF_NAMESPACE@::@target@)
     include("${CMAKE_CURRENT_LIST_DIR}/@target_export@.cmake")
@@ -9,9 +9,7 @@ endif()
 # $<TARGET_PROPERTY:${QT_PROTOBUF_NAMESPACE}::ProtobufWellKnownTypes,PROTO_INCLUDES>
 # outside the build tree. Expecting that WrapProtobuf sets Protobuf_INCLUDE_DIRS.
 
-if(DEFINED Protobuf_INCLUDE_DIRS)
-    string(JOIN " -I" proto_includes ${Protobuf_INCLUDE_DIRS})
-endif()
+string(JOIN " -I" proto_includes ${Protobuf_INCLUDE_DIRS})
 
 set_target_properties(@QT_PROTOBUF_NAMESPACE@::@target@ PROPERTIES
     PROTO_INCLUDES "-I${proto_includes}"


### PR DESCRIPTION
- WrapProtobuf should only find required for the project needs
  components. E.g. at the build time it's optional to have protoc
  or libprotobuf in place. We may skip build of their dependencies
  instead.

Fixes: #205