### PR TITLE
Rename QGrpcSubscription to QGrpcStream

### DIFF
--- a/examples/addressbook/addressbookengine.cpp
+++ b/examples/addressbook/addressbookengine.cpp
@@ -56,11 +56,11 @@ AddressBookEngine::AddressBookEngine() : QObject()
     std::shared_ptr<QtProtobuf::QAbstractGrpcChannel> channel(new QtProtobuf::QGrpcHttp2Channel(QUrl("https://localhost:65001"), QtProtobuf::QGrpcSslCredentials(conf) |
                                                                                       QtProtobuf::QGrpcUserPasswordCredentials<>("authorizedUser", QCryptographicHash::hash("test", QCryptographicHash::Md5).toHex())));
     m_client->attachChannel(channel);
-    auto stream = m_client->subscribeContacts(ListFrame());
+    auto stream = m_client->streamContacts(ListFrame());
     connect(stream.get(), &QtProtobuf::QGrpcStream::messageReceived, this, [this, stream]() {
         m_contacts->reset(stream->read<Contacts>().list());
     });
-    m_client->subscribeCallStatus(qtprotobuf::examples::None(), QPointer<CallStatus>(&m_callStatus));
+    m_client->streamCallStatus(qtprotobuf::examples::None(), QPointer<CallStatus>(&m_callStatus));
 }
 
 void AddressBookEngine::addContact(qtprotobuf::examples::Contact *contact)

--- a/examples/simplechat/simplechatengine.cpp
+++ b/examples/simplechat/simplechatengine.cpp
@@ -73,7 +73,7 @@ void SimpleChatEngine::login(const QString &name, const QString &password)
                                                                                       QtProtobuf::QGrpcUserPasswordCredentials<>(name, QCryptographicHash::hash(password.toUtf8(), QCryptographicHash::Md5).toHex())));
 
     m_client->attachChannel(channel);
-    QtProtobuf::QGrpcStreamShared stream = m_client->subscribeMessageList(None());
+    QtProtobuf::QGrpcStreamShared stream = m_client->streamMessageList(None());
     QObject::connect(stream.get(), &QtProtobuf::QGrpcStream::error, this, [stream] {
         qCritical() << "Stream error, cancel";
         stream->cancel();

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -334,7 +334,7 @@ const char *Templates::ClientMethodDefinitionQmlTemplate = "\nvoid $classname$::
                                                            "        return;\n"
                                                            "    }\n\n"
                                                            "    QtProtobuf::QGrpcAsyncReplyShared reply = call(\"$method_name$\", *$param_name$);\n"
-                                                           "    reply->subscribe(jsEngine, [this, reply, callback, jsEngine]() {\n"
+                                                           "    reply->stream(jsEngine, [this, reply, callback, jsEngine]() {\n"
                                                            "        auto result = new $return_type$(reply->read<$return_type$>());\n"
                                                            "        qmlEngine(this)->setObjectOwnership(result, QQmlEngine::JavaScriptOwnership);\n"
                                                            "        QJSValue(callback).call(QJSValueList{jsEngine->toScriptValue(result)});\n"
@@ -359,7 +359,7 @@ const char *Templates::ClientMethodDefinitionQml2Template = "\nvoid $classname$:
                                                             "        return;\n"
                                                             "    }\n\n"
                                                             "    QtProtobuf::QGrpcAsyncReplyShared reply = call(\"$method_name$\", *$param_name$);\n"
-                                                            "    reply->subscribe(jsEngine, [this, reply, jsEngine, safeReturn]() {\n"
+                                                            "    reply->stream(jsEngine, [this, reply, jsEngine, safeReturn]() {\n"
                                                             "        if (safeReturn.isNull()) {\n"
                                                             "            qProtoWarning() << \"Return value is destroyed. Ignore call result\";\n"
                                                             "            return;\n"
@@ -378,21 +378,21 @@ const char *Templates::QmlRegisterEnumTypeTemplate = "qmlRegisterUncreatableType
 
 
 const char *Templates::ClientMethodSignalDeclarationTemplate = "Q_SIGNAL void $method_name$Updated(const $return_type$ &);\n";
-const char *Templates::ClientMethodServerStreamDeclarationTemplate = "QtProtobuf::QGrpcStreamShared subscribe$method_name_upper$(const $param_type$ &$param_name$);\n";
-const char *Templates::ClientMethodServerStream2DeclarationTemplate = "QtProtobuf::QGrpcStreamShared subscribe$method_name_upper$(const $param_type$ &$param_name$, const QPointer<$return_type$> &$return_name$);\n";
-const char *Templates::ClientMethodServerStreamQmlDeclarationTemplate = "Q_INVOKABLE QtProtobuf::QGrpcStreamShared qmlSubscribe$method_name_upper$_p($param_type$ *$param_name$, $return_type$ *$return_name$);\n";
+const char *Templates::ClientMethodServerStreamDeclarationTemplate = "QtProtobuf::QGrpcStreamShared stream$method_name_upper$(const $param_type$ &$param_name$);\n";
+const char *Templates::ClientMethodServerStream2DeclarationTemplate = "QtProtobuf::QGrpcStreamShared stream$method_name_upper$(const $param_type$ &$param_name$, const QPointer<$return_type$> &$return_name$);\n";
+const char *Templates::ClientMethodServerStreamQmlDeclarationTemplate = "Q_INVOKABLE QtProtobuf::QGrpcStreamShared qmlStream$method_name_upper$_p($param_type$ *$param_name$, $return_type$ *$return_name$);\n";
 
-const char *Templates::ClientMethodServerStreamDefinitionTemplate = "QtProtobuf::QGrpcStreamShared $classname$::subscribe$method_name_upper$(const $param_type$ &$param_name$)\n"
+const char *Templates::ClientMethodServerStreamDefinitionTemplate = "QtProtobuf::QGrpcStreamShared $classname$::stream$method_name_upper$(const $param_type$ &$param_name$)\n"
                                                                     "{\n"
-                                                                    "    return subscribe(\"$method_name$\", $param_name$);\n"
+                                                                    "    return stream(\"$method_name$\", $param_name$);\n"
                                                                     "}\n";
-const char *Templates::ClientMethodServerStream2DefinitionTemplate = "QtProtobuf::QGrpcStreamShared $classname$::subscribe$method_name_upper$(const $param_type$ &$param_name$, const QPointer<$return_type$> &$return_name$)\n"
+const char *Templates::ClientMethodServerStream2DefinitionTemplate = "QtProtobuf::QGrpcStreamShared $classname$::stream$method_name_upper$(const $param_type$ &$param_name$, const QPointer<$return_type$> &$return_name$)\n"
                                                                      "{\n"
-                                                                     "    return subscribe(\"$method_name$\", $param_name$, $return_name$);\n"
+                                                                     "    return stream(\"$method_name$\", $param_name$, $return_name$);\n"
                                                                      "}\n";
-const char *Templates::ClientMethodServerStreamQmlDefinitionTemplate = "QtProtobuf::QGrpcStreamShared $classname$::qmlSubscribe$method_name_upper$_p($param_type$ *$param_name$, $return_type$ *$return_name$)\n"
+const char *Templates::ClientMethodServerStreamQmlDefinitionTemplate = "QtProtobuf::QGrpcStreamShared $classname$::qmlStream$method_name_upper$_p($param_type$ *$param_name$, $return_type$ *$return_name$)\n"
                                                                        "{\n"
-                                                                       "    return subscribe(\"$method_name$\", *$param_name$, QPointer<$return_type$>($return_name$));\n"
+                                                                       "    return stream(\"$method_name$\", *$param_name$, QPointer<$return_type$>($return_name$));\n"
                                                                        "}\n";
 
 const char *Templates::ListSuffix = "Repeated";

--- a/src/grpc/qabstractgrpcchannel.h
+++ b/src/grpc/qabstractgrpcchannel.h
@@ -78,14 +78,14 @@ public:
     virtual void call(const QString &method, const QString &service, const QByteArray &args, QtProtobuf::QGrpcAsyncReply *ret) = 0;
 
     /*!
-     * \brief Subscribes to server-side stream to receive updates for given \p method.
+     * \brief Streams to server-side stream to receive updates for given \p method.
      *        \note This method should not be called directly.
      * \param[in] method remote method is called
      * \param[in] service service identified in URL path format
      * \param[in] args serialized argument message
      * \param[in] handler callback that will be called when message recevied from the server-stream
      */
-    virtual void subscribe(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client) = 0;
+    virtual void stream(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client) = 0;
 
     virtual std::shared_ptr<QAbstractProtobufSerializer> serializer() const = 0;
 
@@ -107,7 +107,7 @@ protected:
     /*!
      * \private
      * \brief Cancels \p stream
-     * \param[in] stream returned by QAbstractGrpcChannel::subscribe() method
+     * \param[in] stream returned by QAbstractGrpcChannel::stream() method
      */
     virtual void cancel(QGrpcStream *stream);
 

--- a/src/grpc/qgrpcasyncreply.h
+++ b/src/grpc/qgrpcasyncreply.h
@@ -53,10 +53,10 @@ public:
     void abort();
 
     /*!
-     * \brief Subscribe to QGrpcAsyncReply signals
+     * \brief Stream to QGrpcAsyncReply signals
      */
     template <typename Func1, typename Func2>
-    inline void subscribe(QObject *receiver, Func1 finishCallback, Func2 errorCallback,
+    inline void stream(QObject *receiver, Func1 finishCallback, Func2 errorCallback,
                                      Qt::ConnectionType type = Qt::AutoConnection)
     {
         QObject::connect(this, &QGrpcAsyncReply::finished, receiver, finishCallback, type);
@@ -64,11 +64,11 @@ public:
     }
 
     /*!
-     * \brief Overloaded QGrpcAsyncReply::subscribe method, to subscribe to finished signal
+     * \brief Overloaded QGrpcAsyncReply::stream method, to stream to finished signal
      *        only
      */
     template <typename Func1>
-    inline void subscribe(QObject *receiver, Func1 finishCallback,
+    inline void stream(QObject *receiver, Func1 finishCallback,
                                      Qt::ConnectionType type = Qt::AutoConnection)
     {
         QObject::connect(this, &QGrpcAsyncReply::finished, receiver, finishCallback, type);

--- a/src/grpc/qgrpcchannel.cpp
+++ b/src/grpc/qgrpcchannel.cpp
@@ -256,7 +256,7 @@ QGrpcStatus QGrpcChannelPrivate::call(const QString &method, const QString &serv
     return call.status;
 }
 
-void QGrpcChannelPrivate::subscribe(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client)
+void QGrpcChannelPrivate::stream(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client)
 {
     assert(stream != nullptr);
 
@@ -335,9 +335,9 @@ void QGrpcChannel::call(const QString &method, const QString &service, const QBy
     dPtr->call(method, service, args, reply);
 }
 
-void QGrpcChannel::subscribe(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client)
+void QGrpcChannel::stream(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client)
 {
-    dPtr->subscribe(stream, service, client);
+    dPtr->stream(stream, service, client);
 }
 
 std::shared_ptr<QAbstractProtobufSerializer> QGrpcChannel::serializer() const

--- a/src/grpc/qgrpcchannel.h
+++ b/src/grpc/qgrpcchannel.h
@@ -58,7 +58,7 @@ public:
 
     QGrpcStatus call(const QString &method, const QString &service, const QByteArray &args, QByteArray &ret) override;
     void call(const QString &method, const QString &service, const QByteArray &args, QtProtobuf::QGrpcAsyncReply *reply) override;
-    void subscribe(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client) override;
+    void stream(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client) override;
     std::shared_ptr<QAbstractProtobufSerializer> serializer() const override;
 
 private:

--- a/src/grpc/qgrpcchannel_p.h
+++ b/src/grpc/qgrpcchannel_p.h
@@ -101,7 +101,7 @@ struct QGrpcChannelPrivate {
 
     void call(const QString &method, const QString &service, const QByteArray &args, QGrpcAsyncReply *reply);
     QGrpcStatus call(const QString &method, const QString &service, const QByteArray &args, QByteArray &ret);
-    void subscribe(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client);
+    void stream(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client);
 };
 
 };

--- a/src/grpc/qgrpchttp2channel.h
+++ b/src/grpc/qgrpchttp2channel.h
@@ -57,7 +57,7 @@ public:
 
     QGrpcStatus call(const QString &method, const QString &service, const QByteArray &args, QByteArray &ret) override;
     void call(const QString &method, const QString &service, const QByteArray &args, QtProtobuf::QGrpcAsyncReply *reply) override;
-    void subscribe(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client) override;
+    void stream(QGrpcStream *stream, const QString &service, QAbstractGrpcClient *client) override;
     std::shared_ptr<QAbstractProtobufSerializer> serializer() const override;
 private:
     Q_DISABLE_COPY_MOVE(QGrpcHttp2Channel)

--- a/src/grpc/quick/qquickgrpcstream.cpp
+++ b/src/grpc/quick/qquickgrpcstream.cpp
@@ -64,19 +64,19 @@ void QQuickGrpcStream::updateStream()
         return;
     }
 
-    if (!subscribe()) {
+    if (!stream()) {
         setEnabled(false);
     }
 }
 
-bool QQuickGrpcStream::subscribe()
+bool QQuickGrpcStream::stream()
 {
     QString uppercaseMethodName = m_method;
     uppercaseMethodName.replace(0, 1, m_method[0].toUpper());
     const QMetaObject *metaObject = m_client->metaObject();
     QMetaMethod method;
     for (int i = 0; i < metaObject->methodCount(); i++) {
-        if (QString("qmlSubscribe%1_p").arg(uppercaseMethodName) == metaObject->method(i).name()) {
+        if (QString("qmlStream%1_p").arg(uppercaseMethodName) == metaObject->method(i).name()) {
             method = metaObject->method(i);
             break;
         }

--- a/src/grpc/quick/qquickgrpcstream_p.h
+++ b/src/grpc/quick/qquickgrpcstream_p.h
@@ -35,7 +35,7 @@
  * \brief GrpcStream provides access to gRPC streams from QML.
  *
  * \details GrpcStream might be used from QML code to receive updates for gRPC server or bidirectional streaming methods.
- * Follwing properties should be provided and can not be empty, to subscribe streaming method:
+ * Follwing properties should be provided and can not be empty, to stream streaming method:
  * - client
  * - method
  * - argument
@@ -178,7 +178,7 @@ signals:
 
 private:
     void updateStream();
-    bool subscribe();
+    bool stream();
     QPointer<QAbstractGrpcClient> m_client;
     bool m_enabled;
     QString m_method;


### PR DESCRIPTION
- Replace 'subscription' term with the 'stream' across the project
- Rename the 'updated' signal of QGrpcSubscription to
  'messageReceived'
- Remove 'Updates' suffix from the generated stream subscribe method
  names.
- Update QML gRPC tests. Use unique message identifiers.