### PR TITLE
Remove const modifier from the return value of a message field getter

### DIFF
--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -180,8 +180,8 @@ const char *Templates::GetterPrivateMessageDefinitionTemplate = "$getter_type$ *
                                                                 "    return m_$property_name$.get();\n"
                                                                 "}\n\n";
 
-const char *Templates::GetterMessageDeclarationTemplate = "const $getter_type$ &$property_name$() const;\n";
-const char *Templates::GetterMessageDefinitionTemplate = "const $getter_type$ &$classname$::$property_name$() const\n{\n"
+const char *Templates::GetterMessageDeclarationTemplate = "$getter_type$ &$property_name$() const;\n";
+const char *Templates::GetterMessageDefinitionTemplate = "$getter_type$ &$classname$::$property_name$() const\n{\n"
                                                          "    return *m_$property_name$;\n"
                                                          "}\n\n";
 

--- a/tests/test_protobuf/simpletest.cpp.inc
+++ b/tests/test_protobuf/simpletest.cpp.inc
@@ -976,5 +976,12 @@ TEST_F(SimpleTest, SimpleInt32ComplexMessageMapMessageCompareTest)
     SimpleInt32ComplexMessageMapMessage test2 = SimpleInt32ComplexMessageMapMessage({{20, msg3}, {30, msg4}});
     ASSERT_TRUE(test1 == test2);
 }
+
+TEST_F(SimpleTest, AccessMessageFieldsFromGetter)
+{
+    ComplexMessage msg1;
+    msg1.testComplexField().setTestFieldString("AccessMessageFieldsFromGetter");
+    ASSERT_TRUE(msg1 == ComplexMessage(0, {"AccessMessageFieldsFromGetter"}));
+}
 } // tests
 } // qtprotobuf


### PR DESCRIPTION
- Getter had const modifier because of one of initial implementation
  when the reference to the class member was returned. Now when getter
  dereferences shared pointer it's easy to do.
- Add tests

Fixes #253