### PR TITLE
Fix the name of the enum list

### DIFF
--- a/src/generator/messagedeclarationprinter.cpp
+++ b/src/generator/messagedeclarationprinter.cpp
@@ -226,7 +226,13 @@ void MessageDeclarationPrinter::printProperties()
         } else if (common::hasQmlAlias(field)) {
             propertyTemplate = Templates::NonScriptablePropertyTemplate;
         } else if (field->is_repeated() && !field->is_map()) {
-            propertyTemplate = Templates::RepeatedPropertyTemplate;
+            // Non-message list properties don't require an extra QQmlListProperty to access
+            // their data, so the property name should not contain the 'Data' suffix
+            if (field->type() == FieldDescriptor::TYPE_MESSAGE) {
+                propertyTemplate = Templates::RepeatedMessagePropertyTemplate;
+            } else {
+                propertyTemplate = Templates::RepeatedPropertyTemplate;
+            }
         }
         mPrinter->Print(common::producePropertyMap(field, mDescriptor), propertyTemplate);
     }

--- a/src/generator/templates.cpp
+++ b/src/generator/templates.cpp
@@ -86,7 +86,8 @@ const char *Templates::ProtoClassDeclarationBeginTemplate = "\nclass $classname$
                                                             "    Q_DECLARE_PROTOBUF_SERIALIZERS($classname$)\n";
 
 const char *Templates::PropertyTemplate = "Q_PROPERTY($property_type$ $property_name$ READ $property_name$ WRITE set$property_name_cap$ NOTIFY $property_name$Changed SCRIPTABLE $scriptable$)\n";
-const char *Templates::RepeatedPropertyTemplate = "Q_PROPERTY($property_list_type$ $property_name$Data READ $property_name$ WRITE set$property_name_cap$ NOTIFY $property_name$Changed SCRIPTABLE $scriptable$)\n";
+const char *Templates::RepeatedPropertyTemplate = "Q_PROPERTY($property_list_type$ $property_name$ READ $property_name$ WRITE set$property_name_cap$ NOTIFY $property_name$Changed SCRIPTABLE $scriptable$)\n";
+const char *Templates::RepeatedMessagePropertyTemplate = "Q_PROPERTY($property_list_type$ $property_name$Data READ $property_name$ WRITE set$property_name_cap$ NOTIFY $property_name$Changed SCRIPTABLE $scriptable$)\n";
 const char *Templates::NonScriptablePropertyTemplate = "Q_PROPERTY($property_type$ $property_name$_p READ $property_name$ WRITE set$property_name_cap$ NOTIFY $property_name$Changed SCRIPTABLE false)\n";
 const char *Templates::NonScriptableAliasPropertyTemplate = "Q_PROPERTY($qml_alias_type$ $property_name$ READ $property_name$_p WRITE set$property_name_cap$_p NOTIFY $property_name$Changed SCRIPTABLE true)\n";
 const char *Templates::MessagePropertyTemplate = "Q_PROPERTY($property_type$ *$property_name$ READ $property_name$_p WRITE set$property_name_cap$_p NOTIFY $property_name$Changed)\n";

--- a/src/generator/templates.h
+++ b/src/generator/templates.h
@@ -70,6 +70,7 @@ public:
 
     static const char *PropertyTemplate;
     static const char *RepeatedPropertyTemplate;
+    static const char *RepeatedMessagePropertyTemplate;
     static const char *NonScriptablePropertyTemplate;
     static const char *NonScriptableAliasPropertyTemplate;
     static const char *MessagePropertyTemplate;

--- a/tests/test_extra_namespace_qml/test.h
+++ b/tests/test_extra_namespace_qml/test.h
@@ -43,6 +43,9 @@ public:
 public slots:
     void qmlEngineAvailable(QQmlEngine *engine)
     {
-        engine->rootContext()->setContextProperty("qVersion", QT_VERSION);
+        QVersionNumber qtVersion = QVersionNumber::fromString(qVersion());
+        engine->rootContext()->setContextProperty("qVersion", qVersion());
+        engine->rootContext()->setContextProperty("qVersionMajor", qtVersion.majorVersion());
+        engine->rootContext()->setContextProperty("qVersionMinor", qtVersion.minorVersion());
     }
 };

--- a/tests/test_grpc_qml/test.h
+++ b/tests/test_grpc_qml/test.h
@@ -59,6 +59,9 @@ public:
 public slots:
     void qmlEngineAvailable(QQmlEngine *engine)
     {
-        engine->rootContext()->setContextProperty("qVersion", QT_VERSION);
+        QVersionNumber qtVersion = QVersionNumber::fromString(qVersion());
+        engine->rootContext()->setContextProperty("qVersion", qVersion());
+        engine->rootContext()->setContextProperty("qVersionMajor", qtVersion.majorVersion());
+        engine->rootContext()->setContextProperty("qVersionMinor", qtVersion.minorVersion());
     }
 };

--- a/tests/test_protobuf/simpletest.cpp.inc
+++ b/tests/test_protobuf/simpletest.cpp.inc
@@ -267,7 +267,7 @@ TEST_F(SimpleTest, SimpleLocalEnumListTest)
 {
     ASSERT_GT(SimpleEnumListMessage::staticMetaObject.enumeratorCount(), 0);
 
-    const char *propertyName = "localEnumListData";
+    const char *propertyName = "localEnumList";
     assertMessagePropertyRegistered<SimpleEnumListMessage, SimpleEnumListMessage::LocalEnumRepeated>(1,  "qtprotobufnamespace::tests::SimpleEnumListMessage::LocalEnumRepeated", propertyName);
 
     SimpleEnumListMessage::LocalEnumRepeated value({SimpleEnumListMessage::LOCAL_ENUM_VALUE2,
@@ -338,7 +338,7 @@ TEST_F(SimpleTest, SimpleEnumsTest)
 
 TEST_F(SimpleTest, SimpleFileEnumsTest)
 {
-    const char *propertyName = "globalEnumListData";
+    const char *propertyName = "globalEnumList";
     assertMessagePropertyRegistered<SimpleFileEnumMessage, qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated>(2, "qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated", propertyName);
 
     qtprotobufnamespace::tests::TestEnumGadget::TestEnumRepeated value{qtprotobufnamespace::tests::TestEnumGadget::TEST_ENUM_VALUE1,
@@ -378,7 +378,7 @@ TEST_F(SimpleTest, SimpleBytesMessageTest)
 
 TEST_F(SimpleTest, SimpleExternalComplexMessageTest)
 {
-    const char *propertyName = "localListData";
+    const char *propertyName = "localList";
     assertMessagePropertyRegistered<qtprotobufnamespace1::externaltests::SimpleExternalMessage, int32List>(
                 1, "QtProtobuf::int32List", propertyName);
 
@@ -411,7 +411,7 @@ TEST_F(SimpleTest, RepeatedExternalComplexMessageTest)
 
 TEST_F(SimpleTest, RepeatedStringMessageTest)
 {
-    const char *propertyName = "testRepeatedStringData";
+    const char *propertyName = "testRepeatedString";
     assertMessagePropertyRegistered<RepeatedStringMessage, QStringList>(1, "QStringList", propertyName);
 
     RepeatedStringMessage test;
@@ -422,7 +422,7 @@ TEST_F(SimpleTest, RepeatedStringMessageTest)
 
 TEST_F(SimpleTest, RepeatedIntMessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedIntMessage, int32List>(1, "QtProtobuf::int32List", propertyName);
 
     RepeatedIntMessage test;
@@ -439,7 +439,7 @@ TEST_F(SimpleTest, RepeatedIntMessageTest)
 
 TEST_F(SimpleTest, RepeatedDoubleMessageTest)
 {
-    const char *propertyName = "testRepeatedDoubleData";
+    const char *propertyName = "testRepeatedDouble";
     assertMessagePropertyRegistered<RepeatedDoubleMessage, DoubleList>(1, "QtProtobuf::DoubleList", propertyName);
 
     RepeatedDoubleMessage test;
@@ -456,7 +456,7 @@ TEST_F(SimpleTest, RepeatedDoubleMessageTest)
 
 TEST_F(SimpleTest, RepeatedFloatMessageTest)
 {
-    const char *propertyName = "testRepeatedFloatData";
+    const char *propertyName = "testRepeatedFloat";
     assertMessagePropertyRegistered<RepeatedFloatMessage, FloatList>(1, "QtProtobuf::FloatList", propertyName);
 
     RepeatedFloatMessage test;
@@ -473,7 +473,7 @@ TEST_F(SimpleTest, RepeatedFloatMessageTest)
 
 TEST_F(SimpleTest, RepeatedBytesMessageTest)
 {
-    const char *propertyName = "testRepeatedBytesData";
+    const char *propertyName = "testRepeatedBytes";
     assertMessagePropertyRegistered<RepeatedBytesMessage, QByteArrayList>(1, "QByteArrayList", propertyName);
 
     QByteArrayList bList;
@@ -496,7 +496,7 @@ TEST_F(SimpleTest, RepeatedBytesMessageTest)
 
 TEST_F(SimpleTest, RepeatedSIntMessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedSIntMessage, sint32List>(1, "QtProtobuf::sint32List", propertyName);
 
     RepeatedSIntMessage test;
@@ -513,7 +513,7 @@ TEST_F(SimpleTest, RepeatedSIntMessageTest)
 
 TEST_F(SimpleTest, RepeatedUIntMessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedUIntMessage, uint32List>(1, "QtProtobuf::uint32List", propertyName);
 
     RepeatedUIntMessage test;
@@ -530,7 +530,7 @@ TEST_F(SimpleTest, RepeatedUIntMessageTest)
 
 TEST_F(SimpleTest, RepeatedInt64MessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedInt64Message, int64List>(1, "QtProtobuf::int64List", propertyName);
 
     RepeatedInt64Message test;
@@ -547,7 +547,7 @@ TEST_F(SimpleTest, RepeatedInt64MessageTest)
 
 TEST_F(SimpleTest, RepeatedSInt64MessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedSInt64Message, sint64List>(1, "QtProtobuf::sint64List", propertyName);
 
     RepeatedSInt64Message test;
@@ -564,7 +564,7 @@ TEST_F(SimpleTest, RepeatedSInt64MessageTest)
 
 TEST_F(SimpleTest, RepeatedUInt64MessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedUInt64Message, uint64List>(1, "QtProtobuf::uint64List", propertyName);
 
     RepeatedUInt64Message test;
@@ -581,7 +581,7 @@ TEST_F(SimpleTest, RepeatedUInt64MessageTest)
 
 TEST_F(SimpleTest, RepeatedFixedIntMessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedFixedIntMessage, fixed32List>(1, "QtProtobuf::fixed32List", propertyName);
 
     RepeatedFixedIntMessage test;
@@ -598,7 +598,7 @@ TEST_F(SimpleTest, RepeatedFixedIntMessageTest)
 
 TEST_F(SimpleTest, RepeatedFixedInt64MessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedFixedInt64Message, fixed64List>(1, "QtProtobuf::fixed64List", propertyName);
 
     RepeatedFixedInt64Message test;
@@ -615,7 +615,7 @@ TEST_F(SimpleTest, RepeatedFixedInt64MessageTest)
 
 TEST_F(SimpleTest, RepeatedSFixedIntMessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedSFixedIntMessage, sfixed32List>(1, "QtProtobuf::sfixed32List", propertyName);
 
     RepeatedSFixedIntMessage test;
@@ -632,7 +632,7 @@ TEST_F(SimpleTest, RepeatedSFixedIntMessageTest)
 
 TEST_F(SimpleTest, RepeatedSFixedInt64MessageTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     assertMessagePropertyRegistered<RepeatedSFixedInt64Message, QtProtobuf::sfixed64List>(1, "QtProtobuf::sfixed64List", propertyName);
 
     RepeatedSFixedInt64Message test;
@@ -660,7 +660,7 @@ TEST_F(SimpleTest, StepChildEnumMessageTest)
 
 TEST_F(SimpleTest, StepChildEnumListMessageTest)
 {
-    const char *propertyName = "localStepChildListData";
+    const char *propertyName = "localStepChildList";
     assertMessagePropertyRegistered<StepChildEnumMessage, SimpleEnumMessage::LocalEnumRepeated>(2, "qtprotobufnamespace::tests::SimpleEnumMessage::LocalEnumRepeated", propertyName);
 
     SimpleEnumMessage::LocalEnumRepeated value({SimpleEnumMessage::LOCAL_ENUM_VALUE2,
@@ -765,7 +765,7 @@ TEST_F(SimpleTest, MoveOperatorTest)
 
 TEST_F(SimpleTest, MoveOperatorRepeatedTest)
 {
-    const char *propertyName = "testRepeatedIntData";
+    const char *propertyName = "testRepeatedInt";
     RepeatedIntMessage test;
     RepeatedIntMessage test2{{55,44,11,33}};
 

--- a/tests/test_qml/qml/tst_simple.qml
+++ b/tests/test_qml/qml/tst_simple.qml
@@ -62,6 +62,11 @@ TestCase {
         testFieldString: "Test string"
     }
 
+    SimpleFileEnumMessage {
+        id: enumListMessage
+        globalEnumList: [TestEnum.TEST_ENUM_VALUE0, TestEnum.TEST_ENUM_VALUE1]
+    }
+
     MessageUpperCase {
         id: caseSenseMsg
     }
@@ -342,5 +347,15 @@ TestCase {
         compare(noPackageMessageUser.testField.testFieldInt, 42, "Package-less message contains invalid value");
         noPackageMessageUser.testField.testFieldInt = 43;
         compare(noPackageMessageUser.testField.testFieldInt, 43, "Package-less message contains invalid value");
+    }
+
+    function test_enumListMessage() {
+        if (qVersionMajor > 6 && qVersionMinor > 3) { // This was only fixed in Qt6 (perhaps in the version greater than or equal to 6.3)
+            compare(enumListMessage.globalEnumList.length, 2, "Global enum list size differs the expected one");
+            compare(typeof(enumListMessage.globalEnumList[1]), typeof(TestEnum.TEST_ENUM_VALUE1), "Global enum list value type doesn't match the enum type");
+            compare(enumListMessage.globalEnumList[1], TestEnum.TEST_ENUM_VALUE1, "Global enum list value 1 doesn't match");
+        } else {
+            verify(enumListMessage.globalEnumList[0] == TestEnum.TEST_ENUM_VALUE0)
+        }
     }
 }

--- a/tests/test_qml/test.h
+++ b/tests/test_qml/test.h
@@ -43,6 +43,9 @@ public:
 public slots:
     void qmlEngineAvailable(QQmlEngine *engine)
     {
-        engine->rootContext()->setContextProperty("qVersion", QT_VERSION);
+        QVersionNumber qtVersion = QVersionNumber::fromString(qVersion());
+        engine->rootContext()->setContextProperty("qVersion", qVersion());
+        engine->rootContext()->setContextProperty("qVersionMajor", qtVersion.majorVersion());
+        engine->rootContext()->setContextProperty("qVersionMinor", qtVersion.minorVersion());
     }
 };

--- a/tests/test_wellknowntypes/simpletest.cpp
+++ b/tests/test_wellknowntypes/simpletest.cpp
@@ -120,7 +120,7 @@ TEST_F(WellknowntypesTest, EmptyTest)
 TEST_F(WellknowntypesTest, FieldMaskTest)
 {
     ASSERT_GT(qMetaTypeId<FieldMask>(), 0);
-    assertMessagePropertyRegistered<FieldMask, QStringList>(1, "QStringList", "pathsData");
+    assertMessagePropertyRegistered<FieldMask, QStringList>(1, "QStringList", "paths");
 }
 
 TEST_F(WellknowntypesTest, SourceContextTest)
@@ -162,11 +162,10 @@ TEST_F(WellknowntypesTest, TimestampTest)
 TEST_F(WellknowntypesTest, TypeTest)
 {
     ASSERT_GT(qMetaTypeId<Type>(), 0);
-    Q_PROPERTY(QStringList oneofs READ oneofs WRITE setOneofs NOTIFY oneofsChanged)
 
     assertMessagePropertyRegistered<Type, QString>(1, "QString", "name");
     assertMessagePropertyRegistered<Type, FieldRepeated>(2, "google::protobuf::FieldRepeated", "fieldsData");
-    assertMessagePropertyRegistered<Type, QStringList>(3, "QStringList", "oneofsData");
+    assertMessagePropertyRegistered<Type, QStringList>(3, "QStringList", "oneofs");
     assertMessagePropertyRegistered<Type, OptionRepeated>(4, "google::protobuf::OptionRepeated", "optionsData");
     assertMessagePropertyRegistered<Type, SourceContext *>(5, "google::protobuf::SourceContext*", "sourceContext", true);
     assertMessagePropertyRegistered<Type, SyntaxGadget::Syntax>(6, "google::protobuf::SyntaxGadget::Syntax", "syntax");


### PR DESCRIPTION
- Remove 'Data' suffix from the enum list name.
- Add Qml tests for the enum lists.
- Expose the extended Qt version in Qml tests

Note: The elementrs of the enum list are represented as 'object's
in QML. That makes impossible to compare them with the enum value.
This was fixed in Qt 6 already, and perhaps in commercial releases
of Qt5.

Fixes #255