### PR TITLE
Fix handling of gRPC errors when the stream is finished

### DIFF
--- a/src/grpc/qabstractgrpcclient.cpp
+++ b/src/grpc/qabstractgrpcclient.cpp
@@ -66,6 +66,9 @@ void QAbstractGrpcClient::attachChannel(const std::shared_ptr<QAbstractGrpcChann
                            "You have to be confident that channel routines are working in the same thread as QAbstractGrpcClient";
         throw std::runtime_error("Call from another thread");
     }
+    for (auto stream : dPtr->activeStreams) {
+        stream->cancel();
+    }
     dPtr->channel = channel;
     dPtr->serializer = channel->serializer();
 }


### PR DESCRIPTION
- Handle the gRPC errors if the assigned QNetworkReply is finished
  without network error and send the QGrpcStream::finish() signal
  if no gRPC error received from server.
- Cancel all gRPC streams when re-attaching the channel.

Fixes #259