### PR TITLE
the libprotoc17 dependency is redundant and causes issues with ubuntu 22.04

### DIFF
--- a/cmake/deb.cmake
+++ b/cmake/deb.cmake
@@ -1,6 +1,6 @@
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "protobuf-compiler (>= 3.6.0), libprotoc17 (>= 3.6.0), golang (>= 1.10.0), libqt5core5a (>= 5.12.4), libqt5qml5 (>= 5.12.4), libqt5network5 (>= 5.12.4), libqt5quick5 (>= 5.12.4)")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "protobuf-compiler (>= 3.6.0), golang (>= 1.10.0), libqt5core5a (>= 5.12.4), libqt5qml5 (>= 5.12.4), libqt5network5 (>= 5.12.4), libqt5quick5 (>= 5.12.4)")
 set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "lib${CPACK_PACKAGE_NAME} (= ${PROJECT_VERSION}), qtdeclarative5-dev (>= 5.12.4), qtbase5-dev (>= 5.12.4), libgrpc-dev (>= 1.15.0), libgrpc++-dev (>= 1.15.0), libprotoc-dev (>= 3.6.0)")
 set(CPACK_DEBIAN_COMPRESSION_TYPE "gzip")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")


### PR DESCRIPTION
that is, redundant to the `protobuf-compiler` dependency:
```bash
root@c83c70b8da59:/# apt info protobuf-compiler
Package: protobuf-compiler
Version: 3.12.4-1ubuntu7
<snip>
Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.3.1), libprotoc23 (= 3.12.4-1ubuntu7), libstdc++6 (>= 5.2)
<snip>
root@c83c70b8da59:/# apt info libprotoc23      
Package: libprotoc23
Version: 3.12.4-1ubuntu7
<snip>
Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.3.1), libprotobuf23 (>= 3.12.4), libstdc++6 (>= 11)
```